### PR TITLE
Remove Deprecated new buffer usage

### DIFF
--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-azure",
-    "version": "1.2.0-beta.7",
+    "version": "1.2.0-beta.8",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/azure/src/__test__/dummyEncoder.ts
+++ b/packages/azure/src/__test__/dummyEncoder.ts
@@ -16,8 +16,8 @@ export class DummyMessageEncoder implements IMessageEncoder {
     // { type: "Buffer", data: [...] }
     public encode(msg: IMessage): Uint8Array {
         const s = JSON.stringify(msg.payload);
-        const buffer = new Buffer(s);
-        return new Buffer(JSON.stringify(buffer.toJSON()));
+        const buffer = Buffer.from(s);
+        return Buffer.from(JSON.stringify(buffer.toJSON()));
     }
 
     public decode(data: Uint8Array, typeName: string): IMessage {

--- a/packages/azure/src/__test__/event-sourced/internal/CosmosStateAggregationSource.test.ts
+++ b/packages/azure/src/__test__/event-sourced/internal/CosmosStateAggregationSource.test.ts
@@ -61,8 +61,8 @@ describe("CosmosStateAggregationSource", () => {
     describe("Healthy Streams", () => {
         it("reads entire stream", async () => {
             const { source, querySpy, snapshotSpy } = await createSource([
-                { sn: 1, event_type: "test", encodedData: { data: new Buffer("test") } },
-                { sn: 2, event_type: "test", encodedData: { data: new Buffer("test") } },
+                { sn: 1, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                { sn: 2, event_type: "test", encodedData: { data: Buffer.from("test") } },
             ]);
 
             const actual = await source.load(undefined, "key-1");
@@ -83,8 +83,8 @@ describe("CosmosStateAggregationSource", () => {
         it("reads snapshot plus missing events", async () => {
             const { source, querySpy, snapshotSpy } = await createSource(
                 [
-                    { sn: 3, event_type: "test", encodedData: { data: new Buffer("test") } },
-                    { sn: 4, event_type: "test", encodedData: { data: new Buffer("test") } },
+                    { sn: 3, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                    { sn: 4, event_type: "test", encodedData: { data: Buffer.from("test") } },
                 ],
                 [2, { foo: "bar" }]
             );
@@ -106,9 +106,9 @@ describe("CosmosStateAggregationSource", () => {
 
         it("reads stream without snapshot till atSn", async () => {
             const { source, querySpy, snapshotSpy } = await createSource([
-                { sn: 1, event_type: "test", encodedData: { data: new Buffer("test") } },
-                { sn: 2, event_type: "test", encodedData: { data: new Buffer("test") } },
-                { sn: 3, event_type: "test", encodedData: { data: new Buffer("test") } },
+                { sn: 1, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                { sn: 2, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                { sn: 3, event_type: "test", encodedData: { data: Buffer.from("test") } },
             ]);
 
             const actual = await source.load(undefined, "key-1", 3);
@@ -128,7 +128,7 @@ describe("CosmosStateAggregationSource", () => {
 
         it("reads stream with snapshot till atSn", async () => {
             const { source, querySpy, snapshotSpy } = await createSource(
-                [{ sn: 3, event_type: "test", encodedData: { data: new Buffer("test") } }],
+                [{ sn: 3, event_type: "test", encodedData: { data: Buffer.from("test") } }],
                 [2, { foo: "bar" }]
             );
 
@@ -150,9 +150,9 @@ describe("CosmosStateAggregationSource", () => {
         it("ignores snapshot newer than atSn", async () => {
             const { source, querySpy, snapshotSpy } = await createSource(
                 [
-                    { sn: 1, event_type: "test", encodedData: { data: new Buffer("test") } },
-                    { sn: 2, event_type: "test", encodedData: { data: new Buffer("test") } },
-                    { sn: 3, event_type: "test", encodedData: { data: new Buffer("test") } },
+                    { sn: 1, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                    { sn: 2, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                    { sn: 3, event_type: "test", encodedData: { data: Buffer.from("test") } },
                 ],
                 [5, { foo: "bar" }]
             );
@@ -176,8 +176,8 @@ describe("CosmosStateAggregationSource", () => {
     describe("Broken Streams", () => {
         it("reads entire stream", async () => {
             const { source, querySpy, snapshotSpy, logSpy } = await createSource([
-                { sn: 1, event_type: "test", encodedData: { data: new Buffer("test") } },
-                { sn: 3, event_type: "test", encodedData: { data: new Buffer("test") } },
+                { sn: 1, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                { sn: 3, event_type: "test", encodedData: { data: Buffer.from("test") } },
             ]);
 
             const actual = await source.load(undefined, "key-1");
@@ -199,8 +199,8 @@ describe("CosmosStateAggregationSource", () => {
         it("reads snapshot plus missing events", async () => {
             const { source, querySpy, snapshotSpy, logSpy } = await createSource(
                 [
-                    { sn: 4, event_type: "test", encodedData: { data: new Buffer("test") } },
-                    { sn: 5, event_type: "test", encodedData: { data: new Buffer("test") } },
+                    { sn: 4, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                    { sn: 5, event_type: "test", encodedData: { data: Buffer.from("test") } },
                 ],
                 [2, { foo: "bar" }]
             );
@@ -223,9 +223,9 @@ describe("CosmosStateAggregationSource", () => {
 
         it("reads stream without snapshot till atSn", async () => {
             const { source, querySpy, snapshotSpy, logSpy } = await createSource([
-                { sn: 1, event_type: "test", encodedData: { data: new Buffer("test") } },
-                { sn: 2, event_type: "test", encodedData: { data: new Buffer("test") } },
-                { sn: 4, event_type: "test", encodedData: { data: new Buffer("test") } },
+                { sn: 1, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                { sn: 2, event_type: "test", encodedData: { data: Buffer.from("test") } },
+                { sn: 4, event_type: "test", encodedData: { data: Buffer.from("test") } },
             ]);
 
             const actual = await source.load(undefined, "key-1", 3);
@@ -246,7 +246,7 @@ describe("CosmosStateAggregationSource", () => {
 
         it("reads stream with snapshot till atSn", async () => {
             const { source, querySpy, snapshotSpy, logSpy } = await createSource(
-                [{ sn: 4, event_type: "test", encodedData: { data: new Buffer("test") } }],
+                [{ sn: 4, event_type: "test", encodedData: { data: Buffer.from("test") } }],
                 [2, { foo: "bar" }]
             );
 

--- a/packages/azure/src/__test__/utils/QueueClient.test.ts
+++ b/packages/azure/src/__test__/utils/QueueClient.test.ts
@@ -145,7 +145,7 @@ describe("QueueClient", () => {
             await expect(client.write(span.context(), payload, headers)).rejects.toEqual(error);
         });
         it("should error if text is to big", async () => {
-            const bigText = new Buffer(65 * 1024);
+            const bigText = Buffer.alloc(65 * 1024);
             const { client, createMessage } = await writeResultsIn();
             const result = client.write(span.context(), bigText, headers);
             expect(createMessage).not.toBeCalled();
@@ -154,7 +154,7 @@ describe("QueueClient", () => {
             );
         });
         it("should error get back 413 from azure", async () => {
-            const bigText = new Buffer(1024);
+            const bigText = Buffer.alloc(1024);
             const e: Error & { statusCode?: number } = new Error(
                 "The request body is too large and exceeds the maximum permissible limit."
             );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.2.0-beta.7",
+    "version": "1.2.0-beta.8",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/defaults/ConventionBasedMessageDispatcher.test.ts
+++ b/packages/core/src/__test__/defaults/ConventionBasedMessageDispatcher.test.ts
@@ -82,7 +82,7 @@ describe("ConventionBasedMessageDispatcher", () => {
     it("invokes function with a encoded message as input", async () => {
         const encoder = new JsonMessageEncoder();
         const buffer = encoder.encode({ type: "test.Trigger", payload: { name: "test" } });
-        const msg = new EncodedMessage(encoder, "test.Trigger", new Buffer(buffer));
+        const msg = new EncodedMessage(encoder, "test.Trigger", Buffer.from(buffer));
 
         const dispatcher = new ConventionBasedMessageDispatcher(new DispatchTarget());
         const ctx = mockContext();

--- a/packages/core/src/__test__/defaults/ConventionBasedStateAggregator.test.ts
+++ b/packages/core/src/__test__/defaults/ConventionBasedStateAggregator.test.ts
@@ -98,7 +98,7 @@ describe("ConventionBasedStateAggregator", () => {
         const encoder = new JsonMessageEncoder();
         const aggregator = new ConventionBasedStateAggregator(TestState, target);
         const invalidMsgType = "invalid.message.type";
-        const invalidEncodedMsg = new Uint8Array(new Buffer("invalid"));
+        const invalidEncodedMsg = new Uint8Array(Buffer.from("invalid"));
 
         const state = aggregator.aggregate({
             lastSn: 4,

--- a/packages/core/src/__test__/defaults/CsvMessageEncoder.test.ts
+++ b/packages/core/src/__test__/defaults/CsvMessageEncoder.test.ts
@@ -25,7 +25,7 @@ describe("CsvMessageEncoder", () => {
             type: Increment.name,
             payload,
         });
-        expect(new Buffer(buffer).toString()).toBe("val1|val2|val3");
+        expect(Buffer.from(buffer).toString()).toBe("val1|val2|val3");
 
         // encodes with a single missing header value
         const missingHeaderBuffer = encoder.encode({
@@ -35,21 +35,21 @@ describe("CsvMessageEncoder", () => {
                 col3: "val3",
             },
         });
-        expect(new Buffer(missingHeaderBuffer).toString()).toBe("val1||val3");
+        expect(Buffer.from(missingHeaderBuffer).toString()).toBe("val1||val3");
 
         // encodes with a single header value
         const singleHeaderVal = encoder.encode({
             type: Increment.name,
             payload: { col2: "val2" },
         });
-        expect(new Buffer(singleHeaderVal).toString()).toBe("|val2|");
+        expect(Buffer.from(singleHeaderVal).toString()).toBe("|val2|");
 
         // encodes with a no header value found
         const noHeaderVal = encoder.encode({
             type: Increment.name,
             payload: { col4: "val4" },
         });
-        expect(new Buffer(noHeaderVal).toString()).toBe("||");
+        expect(Buffer.from(noHeaderVal).toString()).toBe("||");
 
         // encodes with a header val containing empty columns
         const altEncoder = new CsvMessageEncoder(["col1", "", "col3"], delimiter, typeName);
@@ -57,7 +57,7 @@ describe("CsvMessageEncoder", () => {
             type: Increment.name,
             payload,
         });
-        expect(new Buffer(altBuffer).toString()).toBe("val1||val3");
+        expect(Buffer.from(altBuffer).toString()).toBe("val1||val3");
     });
 
     it("decodes", () => {

--- a/packages/core/src/__test__/defaults/EncodedMessage.test.ts
+++ b/packages/core/src/__test__/defaults/EncodedMessage.test.ts
@@ -11,7 +11,7 @@ import { Increment } from "../tally";
 describe("EncodedMessage", () => {
     it("returns the decoded message as payload", () => {
         const encoder = new NullMessageEncoder();
-        const data = new Buffer("test");
+        const data = Buffer.from("test");
         const msg = new EncodedMessage(encoder, "test_type", data);
         expect(msg.payload).toMatchObject(data);
     });
@@ -21,7 +21,7 @@ describe("EncodedMessage", () => {
         const delimiter = "|";
         const typeName = Increment.name;
         const encoder = new CsvMessageEncoder(headers, delimiter, typeName);
-        const data = new Buffer("val1|val2|val3");
+        const data = Buffer.from("val1|val2|val3");
         const msg = new EncodedMessage(encoder, "", data);
         expect(msg).toMatchObject({
             type: typeName,
@@ -36,7 +36,7 @@ describe("EncodedMessage", () => {
     it("returns an already decoded message as payload without decoding twice", () => {
         const encoder = new NullMessageEncoder();
         const spy = jest.spyOn(encoder, "decode");
-        const data = new Buffer("test");
+        const data = Buffer.from("test");
         const msg = new EncodedMessage(encoder, "test_type", data);
         const payloads = [msg.payload, msg.payload];
         expect(payloads).toMatchObject([data, data]);

--- a/packages/core/src/__test__/defaults/JsonMessageEncoder.test.ts
+++ b/packages/core/src/__test__/defaults/JsonMessageEncoder.test.ts
@@ -14,12 +14,12 @@ describe("JsonMessageEncoder", () => {
         const obj = inc(2);
         const buffer = encoder.encode(obj);
 
-        expect(new Buffer(buffer).toString()).toBe(`{"count":2}`);
+        expect(Buffer.from(buffer).toString()).toBe(`{"count":2}`);
     });
 
     it("decodes", () => {
         const encoder = new JsonMessageEncoder();
-        const obj = encoder.decode(new Buffer(`{"count":2}`), "Increment");
+        const obj = encoder.decode(Buffer.from(`{"count":2}`), "Increment");
 
         expect(obj).toMatchObject(inc(2));
     });

--- a/packages/core/src/defaults/CsvMessageEncoder.ts
+++ b/packages/core/src/defaults/CsvMessageEncoder.ts
@@ -21,11 +21,11 @@ export class CsvMessageEncoder implements IMessageEncoder {
         for (const header of this.headers) {
             s.push(msg.payload[header]);
         }
-        return new Buffer(s.join(this.delimiter));
+        return Buffer.from(s.join(this.delimiter));
     }
 
     public decode(data: Uint8Array, typeName?: string): IMessage {
-        const decodedString = new Buffer(data).toString();
+        const decodedString = Buffer.from(data).toString();
         const values: string[] = decodedString.split(this.delimiter);
         if (this.headers.length < values.length) {
             throw new Error("Not enough header values for the returned csv row");

--- a/packages/core/src/defaults/JsonMessageEncoder.ts
+++ b/packages/core/src/defaults/JsonMessageEncoder.ts
@@ -19,13 +19,13 @@ export class JsonMessageEncoder implements IMessageEncoder, IEncodedMessageEmbed
     }
 
     public encode(msg: IMessage): Uint8Array {
-        return new Buffer(JSON.stringify(msg.payload));
+        return Buffer.from(JSON.stringify(msg.payload));
     }
 
     public decode(data: Uint8Array, typeName?: string): IMessage {
         return {
             type: typeName,
-            payload: JSON.parse(new Buffer(data).toString()),
+            payload: JSON.parse(Buffer.from(data).toString()),
         };
     }
 }

--- a/packages/core/src/defaults/NullMessageEncoder.ts
+++ b/packages/core/src/defaults/NullMessageEncoder.ts
@@ -22,7 +22,7 @@ export class NullMessageEncoder implements IMessageEncoder {
     public decode(data: Uint8Array, typeName?: string): IMessage {
         return {
             type: typeName,
-            payload: new Buffer(data),
+            payload: Buffer.from(data),
         };
     }
 }

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -29,7 +29,7 @@ export class SnapshotJsonMessageEncoder implements IMessageEncoder {
 
     public encode(msg: IMessage): Uint8Array {
         if (msg.type === Snapshot.name) {
-            return new Buffer(JSON.stringify(msg.payload));
+            return Buffer.from(JSON.stringify(msg.payload));
         }
 
         throw new Error("unknown message type");
@@ -39,7 +39,7 @@ export class SnapshotJsonMessageEncoder implements IMessageEncoder {
         if (typeName === Snapshot.name) {
             return {
                 type: Snapshot.name,
-                payload: JSON.parse(new Buffer(data).toString()),
+                payload: JSON.parse(Buffer.from(data).toString()),
             };
         }
 

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-gcp",
-    "version": "1.2.0-alpha.2",
+    "version": "1.2.0-alpha.3",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/gcp/src/__test__/GcsClient.test.ts
+++ b/packages/gcp/src/__test__/GcsClient.test.ts
@@ -33,7 +33,7 @@ describe("GcsClient", () => {
 
     describe("Proceeds with expected failure", () => {
         const err = "A DEFINED VALUE";
-        const content = new Buffer("CONTENTS TO BE WRITTEN");
+        const content = Buffer.from("CONTENTS TO BE WRITTEN");
 
         beforeEach(() => {
             MockStorage.mockImplementation(() => {
@@ -62,7 +62,7 @@ describe("GcsClient", () => {
     });
 
     describe("Proceeds with expected success", () => {
-        const content = new Buffer("CONTENTS TO BE WRITTEN");
+        const content = Buffer.from("CONTENTS TO BE WRITTEN");
         beforeEach(() => {
             // tslint:disable-next-line: no-identical-functions
             MockStorage.mockImplementation(() => {

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-grpc",
-    "version": "1.2.0-beta.3",
+    "version": "1.2.0-beta.4",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/grpc/src/internal/pbjs.ts
+++ b/packages/grpc/src/internal/pbjs.ts
@@ -32,7 +32,7 @@ function createServiceMethodDefinition(method: IGrpcServiceMethod): any {
             if (invalid) {
                 throw new Error(`Invalid request: ${invalid}`);
             }
-            return new Buffer(method.requestType.encode(request).finish());
+            return Buffer.from(method.requestType.encode(request).finish());
         },
         requestDeserialize: (buffer: Buffer): any => {
             const request = method.requestType.decode(buffer);
@@ -47,7 +47,7 @@ function createServiceMethodDefinition(method: IGrpcServiceMethod): any {
             if (invalid) {
                 throw new Error(`Invalid response: ${invalid}`);
             }
-            return new Buffer(method.responseType.encode(response).finish());
+            return Buffer.from(method.responseType.encode(response).finish());
         },
         responseDeserialize: (buffer: Buffer): any => {
             const response = method.responseType.decode(buffer);

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kafka",
-    "version": "1.2.0-beta.6",
+    "version": "1.2.0-beta.7",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/kafka/src/KafkaSink.ts
+++ b/packages/kafka/src/KafkaSink.ts
@@ -223,7 +223,7 @@ export class KafkaSink
         let payload: Buffer | null = null;
 
         if (!msg.metadata[KafkaMetadata.Tombstone]) {
-            payload = new Buffer(this.config.encoder.encode(msg.message));
+            payload = Buffer.from(this.config.encoder.encode(msg.message));
         }
 
         const headers = {
@@ -249,7 +249,7 @@ export class KafkaSink
 
         return {
             type: msg.message.type,
-            key: possibleKey ? new Buffer(possibleKey) : null,
+            key: possibleKey ? Buffer.from(possibleKey) : null,
             topic,
             timestamp,
             partition: msg.metadata[KafkaMetadata.Partition],

--- a/packages/kafka/src/__test__/KafkaSource.test.ts
+++ b/packages/kafka/src/__test__/KafkaSource.test.ts
@@ -49,10 +49,10 @@ describe("KafkaSource", () => {
                 topic: topicName,
                 offset,
                 partition,
-                key: new Buffer("key"),
+                key: Buffer.from("key"),
                 headers: { "X-Message-Type": "application/json" },
                 timestamp: "1554845507549",
-                value: new Buffer(encoder.encode({ type: "test", payload: { foo: "bar" } })),
+                value: Buffer.from(encoder.encode({ type: "test", payload: { foo: "bar" } })),
             };
 
             (KafkaConsumer.prototype.consume as any).mockImplementationOnce(
@@ -167,13 +167,13 @@ describe("KafkaSource", () => {
                 topic: topicName,
                 offset,
                 partition,
-                key: new Buffer("key"),
+                key: Buffer.from("key"),
                 headers: {
                     "X-Message-Type": "application/json",
                     [EventSourcedMetadata.EventType]: ShoppingCartCreated.name,
                 },
                 timestamp: "1554845507549",
-                value: new Buffer(
+                value: Buffer.from(
                     encoder.encode({
                         type: ShoppingCartCreated.name,
                         payload: { shoppingCartId: "testId" },
@@ -228,7 +228,7 @@ describe("KafkaSource", () => {
                     { key: "X-Message-Type", value: "application/x-some-envelope" },
                     { key: EventSourcedMetadata.EventType, value: ShoppingCartCreated.name },
                 ],
-                body: new Buffer(
+                body: Buffer.from(
                     encoder.encode({
                         type: ShoppingCartCreated.name,
                         payload: { shoppingCartId: "testId" },
@@ -240,10 +240,10 @@ describe("KafkaSource", () => {
                 topic: topicName,
                 offset,
                 partition,
-                key: new Buffer("key"),
+                key: Buffer.from("key"),
                 headers: {},
                 timestamp: "1554845507549",
-                value: new Buffer(JSON.stringify(envelope)),
+                value: Buffer.from(JSON.stringify(envelope)),
             };
 
             (KafkaConsumer.prototype.consume as any).mockImplementationOnce(
@@ -264,7 +264,7 @@ describe("KafkaSource", () => {
                         const envelope = JSON.parse(msg.value.toString());
                         return {
                             ...msg,
-                            value: new Buffer(envelope.body),
+                            value: Buffer.from(envelope.body),
                             headers: envelope.headers,
                         };
                     },

--- a/packages/kafka/src/__test__/Partitioner.test.ts
+++ b/packages/kafka/src/__test__/Partitioner.test.ts
@@ -42,7 +42,7 @@ describe("partitioner", () => {
 
         it("should work with key values that are buffers", () => {
             const partitioner = createPartitioner();
-            const options = { partitionMetadata: [{}, {}], message: { key: new Buffer("test") } };
+            const options = { partitionMetadata: [{}, {}], message: { key: Buffer.from("test") } };
 
             expect(partitioner(options)).toEqual(0);
         });

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kubernetes",
-    "version": "1.2.0-beta.11",
+    "version": "1.2.0-beta.12",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/kubernetes/src/KubernetesAdmissionControllerSource.ts
+++ b/packages/kubernetes/src/KubernetesAdmissionControllerSource.ts
@@ -156,7 +156,7 @@ export class KubernetesAdmissionControllerSource implements IInputSource, IRequi
                             handlerReturnVal.modifiedObject
                         );
                         const jsonString = JSON.stringify(patch);
-                        admissionReviewResp.response.patch = new Buffer(jsonString).toString(
+                        admissionReviewResp.response.patch = Buffer.from(jsonString).toString(
                             "base64"
                         );
                     }

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-proto",
-    "version": "1.2.0-beta.1",
+    "version": "1.2.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/proto/src/ProtoJsonMessageEncoder.ts
+++ b/packages/proto/src/ProtoJsonMessageEncoder.ts
@@ -22,11 +22,11 @@ export class ProtoJsonMessageEncoder implements IMessageEncoder, IEncodedMessage
     }
 
     public fromJsonEmbedding(embedding: any): Uint8Array {
-        return new Buffer(JSON.stringify(embedding));
+        return Buffer.from(JSON.stringify(embedding));
     }
 
     public encode(msg: IMessage): Uint8Array {
-        return new Buffer(JSON.stringify(msg.payload));
+        return Buffer.from(JSON.stringify(msg.payload));
     }
 
     public decode(data: Uint8Array, typeName: string): IMessage {

--- a/packages/proto/src/__test__/ProtoJsonMessageEncoder.test.ts
+++ b/packages/proto/src/__test__/ProtoJsonMessageEncoder.test.ts
@@ -38,7 +38,7 @@ describe("ProtoJsonMessageEncoder", () => {
             payload: PAYLOAD,
         });
 
-        expect(buffer).toMatchObject(new Buffer(JSON.stringify(PAYLOAD)));
+        expect(buffer).toMatchObject(Buffer.from(JSON.stringify(PAYLOAD)));
     });
 
     it("creates a JSON object from an encoded IMessage payload json string buffer", async () => {

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-s3",
-    "version": "1.2.0-beta.1",
+    "version": "1.2.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/s3/src/MultipartUploader.ts
+++ b/packages/s3/src/MultipartUploader.ts
@@ -66,7 +66,7 @@ export class MultipartUploader<T> implements IMultipartUploader<T> {
             payload: body,
         };
 
-        const encodedBody = new Buffer(this.encoder.encode(msg));
+        const encodedBody = Buffer.from(this.encoder.encode(msg));
         try {
             const partNumber = this.uploadIdCounter + 1;
             this.uploadIdCounter = partNumber;

--- a/packages/s3/src/S3Client.ts
+++ b/packages/s3/src/S3Client.ts
@@ -117,7 +117,7 @@ export class S3Client implements IS3Client, IRequireInitialization {
             payload: body,
         };
 
-        const encodedBody = new Buffer(this.encoder.encode(msg));
+        const encodedBody = Buffer.from(this.encoder.encode(msg));
         let req: PromiseResult<AWS.S3.PutObjectOutput, AWS.AWSError>;
         let errorCode;
         let statusCode;

--- a/packages/s3/src/__test__/S3.integration.test.ts
+++ b/packages/s3/src/__test__/S3.integration.test.ts
@@ -113,7 +113,7 @@ describe("s3Sink", () => {
         const handlers = {
             onIncrement: async (msg: Increment, ctx: IDispatchContext): Promise<void> => {
                 key = `new_key-${msg.count + 2}`;
-                ctx.publish(Buffer, new Buffer("test_payload" + msg.count), {
+                ctx.publish(Buffer, Buffer.from("test_payload" + msg.count), {
                     [S3Metadata.Key]: key,
                     [S3Metadata.Bucket]: bucket,
                 });
@@ -128,7 +128,7 @@ describe("s3Sink", () => {
         const handlers = {
             onIncrement: async (msg: Increment, ctx: IDispatchContext): Promise<void> => {
                 const key: string = `key-${msg.count}`;
-                ctx.publish(Buffer, new Buffer("test_payload" + msg.count), {
+                ctx.publish(Buffer, Buffer.from("test_payload" + msg.count), {
                     [S3Metadata.Key]: key,
                     [S3Metadata.Bucket]: "invalid_bucket",
                 });
@@ -168,7 +168,7 @@ describe("s3Client", () => {
     });
 
     it("saves objects to an existing s3 compliant backend bucket", async () => {
-        await client.putObject(undefined, Buffer.name, new Buffer(s3Object), bucket, "clientkey");
+        await client.putObject(undefined, Buffer.name, Buffer.from(s3Object), bucket, "clientkey");
     });
 
     it("fails to save objects to non-existent bucket", async () => {
@@ -177,7 +177,7 @@ describe("s3Client", () => {
             await client.putObject(
                 undefined,
                 Buffer.name,
-                new Buffer(s3Object),
+                Buffer.from(s3Object),
                 "invalid_bucket",
                 "clientkey"
             );
@@ -198,11 +198,11 @@ describe("s3Client", () => {
         try {
             // simulate large payloads chucks that are each over 5mb
             const part1 = "1".repeat(6000000);
-            await mp.send(new Buffer(part1));
+            await mp.send(Buffer.from(part1));
             const part2 = "2".repeat(6000000);
-            await mp.send(new Buffer(part2));
+            await mp.send(Buffer.from(part2));
             const part3 = "3".repeat(6000000);
-            await mp.send(new Buffer(part3));
+            await mp.send(Buffer.from(part3));
             await mp.complete();
         } catch (e) {
             error = e;
@@ -211,7 +211,7 @@ describe("s3Client", () => {
     });
 
     it("generates pre-signed urls for get operations", async () => {
-        await client.putObject(undefined, Buffer.name, new Buffer(s3Object), bucket, "clientkey");
+        await client.putObject(undefined, Buffer.name, Buffer.from(s3Object), bucket, "clientkey");
         const url = client.createPresignedReadOnlyUrl(bucket, "clientkey", 5000);
         const response = await fetch(url);
         await expect(response.text()).resolves.toBe("test_blob");


### PR DESCRIPTION
Most usages of `new Buffer` took in some support version of from.  only two usages that actually were allocating a buffer.  The two using alloc are testing the azure queue size restrictions.

Addresses issue #12 