### PR TITLE
kubernetes: update @kubernetes/client-node package to 0.11.1

### DIFF
--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kubernetes",
-    "version": "1.2.0-beta.13",
+    "version": "1.2.0-beta.14",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -13,7 +13,7 @@
         "url": "https://github.com/walmartlabs/cookie-cutter/issues"
     },
     "dependencies": {
-        "@kubernetes/client-node": "git+https://github.com/kubernetes-client/javascript#568a853dc10b41067f66e562853b2ca6d90d9c7b",
+        "@kubernetes/client-node": "0.11.1",
         "body-parser": "1.19.0",
         "express": "4.17.1",
         "express-async-handler": "1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,9 +1103,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@kubernetes/client-node@git+https://github.com/kubernetes-client/javascript#568a853dc10b41067f66e562853b2ca6d90d9c7b":
+"@kubernetes/client-node@0.11.1":
   version "0.11.1"
-  resolved "git+https://github.com/kubernetes-client/javascript#568a853dc10b41067f66e562853b2ca6d90d9c7b"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.11.1.tgz#87ae6a8e4f3d1937acdda5ebc21ce49c18c820ae"
+  integrity sha512-0A4nwErxzJiGt3WYMR6rvcQF46hFz04b6uCmW7Kuj+Cl0zwe7KKxeMiqbZDtHPOq1CcOHOIcKNWCacUKL5CdxQ==
   dependencies:
     "@types/js-yaml" "^3.12.1"
     "@types/node" "^10.12.0"
@@ -6887,22 +6888,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-pre-gyp@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
@@ -9353,7 +9338,7 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^4, tar@^4.4.2:
+tar@^4:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
#48 on the develop branches uses a git commit from master of the [`kubernetes/client-node`](https://github.com/kubernetes-client/javascript) package which isn't ideal. `0.11.1` was just recently released so we can update to that version which has the fix we were looking for. This should also help to alleviate some of the intermittent build issues we've been seeing where [Yarn is unable to find a package](https://github.com/yarnpkg/yarn/issues/2629) during install.

