### PR TITLE
core: update ConsoleLogger to correctly log out nested objects

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.2.0-beta.8",
+    "version": "1.2.0-beta.9",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/defaults/ConsoleLogger.test.ts
+++ b/packages/core/src/__test__/defaults/ConsoleLogger.test.ts
@@ -15,6 +15,13 @@ describe("ConsoleLogger", () => {
         cc: "core",
         file: "ConsoleLogger.test.ts",
         array: ["one", { two: { foo: "bar" } }],
+        maxDepth: {
+            obj1: {
+                obj2: {
+                    obj3: { obj4: { obj5: { obj6: { obj7: "doesn't get here" } } }, key: "val" },
+                },
+            },
+        },
     };
 
     // tslint:disable:no-console
@@ -37,7 +44,7 @@ describe("ConsoleLogger", () => {
     });
 
     it("logs out info msgs", () => {
-        const logger = new ConsoleLogger();
+        const logger = new ConsoleLogger({ maxDepth: 5 });
         logger.info("info logMsg", logMsg);
         logger.info("info nestedLogMsg", nestedLogMsg);
         const msg1 = capturedLogs[0][0];
@@ -52,7 +59,9 @@ describe("ConsoleLogger", () => {
 
         const msg2 = capturedLogs[1][0];
         let cookie;
-        [, info, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        let maxDepth1;
+        let maxDepth2;
+        [, info, msg, foo, cookie, cc, file, arr1, arr2, maxDepth1, maxDepth2] = msg2.split("|");
         expect(info).toBe("  INFO ");
         expect(msg).toBe(" info nestedLogMsg ");
         expect(foo).toBe(" foo.bar.baz=nested_msg ");
@@ -60,11 +69,13 @@ describe("ConsoleLogger", () => {
         expect(cc).toBe(" cc=core ");
         expect(file).toBe(" file=ConsoleLogger.test.ts ");
         expect(arr1).toBe(" array.0=one ");
-        expect(arr2).toBe(" array.1.two.foo=bar");
+        expect(arr2).toBe(" array.1.two.foo=bar ");
+        expect(maxDepth1).toBe(" maxDepth.obj1.obj2.obj3.obj4.obj5=[object Object] ");
+        expect(maxDepth2).toBe(" maxDepth.obj1.obj2.obj3.key=val");
     });
 
     it("logs out debug msgs", () => {
-        const logger = new ConsoleLogger();
+        const logger = new ConsoleLogger({ maxDepth: 5 });
         logger.debug("debug logMsg", logMsg);
         logger.debug("debug nestedLogMsg", nestedLogMsg);
         const msg1 = capturedLogs[0][0];
@@ -79,7 +90,9 @@ describe("ConsoleLogger", () => {
 
         const msg2 = capturedLogs[1][0];
         let cookie;
-        [, debug, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        let maxDepth1;
+        let maxDepth2;
+        [, debug, msg, foo, cookie, cc, file, arr1, arr2, maxDepth1, maxDepth2] = msg2.split("|");
         expect(debug).toBe(" DEBUG ");
         expect(msg).toBe(" debug nestedLogMsg ");
         expect(foo).toBe(" foo.bar.baz=nested_msg ");
@@ -87,11 +100,13 @@ describe("ConsoleLogger", () => {
         expect(cc).toBe(" cc=core ");
         expect(file).toBe(" file=ConsoleLogger.test.ts ");
         expect(arr1).toBe(" array.0=one ");
-        expect(arr2).toBe(" array.1.two.foo=bar");
+        expect(arr2).toBe(" array.1.two.foo=bar ");
+        expect(maxDepth1).toBe(" maxDepth.obj1.obj2.obj3.obj4.obj5=[object Object] ");
+        expect(maxDepth2).toBe(" maxDepth.obj1.obj2.obj3.key=val");
     });
 
     it("logs out warn msgs", () => {
-        const logger = new ConsoleLogger();
+        const logger = new ConsoleLogger({ maxDepth: 5 });
         logger.warn("warn logMsg", logMsg);
         logger.warn("warn nestedLogMsg", nestedLogMsg);
         const msg1 = capturedLogs[0][0];
@@ -106,7 +121,9 @@ describe("ConsoleLogger", () => {
 
         const msg2 = capturedLogs[1][0];
         let cookie;
-        [, warn, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        let maxDepth1;
+        let maxDepth2;
+        [, warn, msg, foo, cookie, cc, file, arr1, arr2, maxDepth1, maxDepth2] = msg2.split("|");
         expect(warn).toBe("  WARN ");
         expect(msg).toBe(" warn nestedLogMsg ");
         expect(foo).toBe(" foo.bar.baz=nested_msg ");
@@ -114,11 +131,13 @@ describe("ConsoleLogger", () => {
         expect(cc).toBe(" cc=core ");
         expect(file).toBe(" file=ConsoleLogger.test.ts ");
         expect(arr1).toBe(" array.0=one ");
-        expect(arr2).toBe(" array.1.two.foo=bar");
+        expect(arr2).toBe(" array.1.two.foo=bar ");
+        expect(maxDepth1).toBe(" maxDepth.obj1.obj2.obj3.obj4.obj5=[object Object] ");
+        expect(maxDepth2).toBe(" maxDepth.obj1.obj2.obj3.key=val");
     });
 
     it("logs out error msgs", () => {
-        const logger = new ConsoleLogger();
+        const logger = new ConsoleLogger({ maxDepth: 5 });
         logger.error("error logMsg", "unable to get data", logMsg);
         logger.error("error nestedLogMsg", "unable to get data", nestedLogMsg);
         const msg1 = capturedLogs[0][0];
@@ -135,7 +154,9 @@ describe("ConsoleLogger", () => {
 
         const msg2 = capturedLogs[2][0];
         let cookie;
-        [, error, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        let maxDepth1;
+        let maxDepth2;
+        [, error, msg, foo, cookie, cc, file, arr1, arr2, maxDepth1, maxDepth2] = msg2.split("|");
         expect(error).toBe(" ERROR ");
         expect(msg).toBe(" error nestedLogMsg ");
         expect(foo).toBe(" foo.bar.baz=nested_msg ");
@@ -143,7 +164,9 @@ describe("ConsoleLogger", () => {
         expect(cc).toBe(" cc=core ");
         expect(file).toBe(" file=ConsoleLogger.test.ts ");
         expect(arr1).toBe(" array.0=one ");
-        expect(arr2).toBe(" array.1.two.foo=bar");
+        expect(arr2).toBe(" array.1.two.foo=bar ");
+        expect(maxDepth1).toBe(" maxDepth.obj1.obj2.obj3.obj4.obj5=[object Object] ");
+        expect(maxDepth2).toBe(" maxDepth.obj1.obj2.obj3.key=val");
         const errMsg2 = capturedLogs[3][0];
         expect(errMsg2).toBe("unable to get data");
     });

--- a/packages/core/src/__test__/defaults/ConsoleLogger.test.ts
+++ b/packages/core/src/__test__/defaults/ConsoleLogger.test.ts
@@ -1,0 +1,150 @@
+/*
+Copyright (c) Walmart Inc.
+
+This source code is licensed under the Apache 2.0 license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+import { ConsoleLogger } from "../../defaults";
+
+describe("ConsoleLogger", () => {
+    const logMsg = { foo: "bar", cc: "core", file: "ConsoleLogger.test.ts", array: ["one", 2] };
+    const nestedLogMsg = {
+        foo: { bar: { baz: "nested_msg" } },
+        cookie: { cutter: "core" },
+        cc: "core",
+        file: "ConsoleLogger.test.ts",
+        array: ["one", { two: { foo: "bar" } }],
+    };
+
+    // tslint:disable:no-console
+    const originalLog = console.log;
+    let capturedLogs = [];
+    beforeAll(() => {
+        // tslint:disable:no-console
+        console.log = function() {
+            capturedLogs.push([].slice.call(arguments));
+        };
+    });
+
+    afterEach(() => {
+        capturedLogs = [];
+    });
+
+    afterAll(() => {
+        // tslint:disable:no-console
+        console.log = originalLog;
+    });
+
+    it("logs out info msgs", () => {
+        const logger = new ConsoleLogger();
+        logger.info("info logMsg", logMsg);
+        logger.info("info nestedLogMsg", nestedLogMsg);
+        const msg1 = capturedLogs[0][0];
+        let [, info, msg, foo, cc, file, arr1, arr2] = msg1.split("|");
+        expect(info).toBe("  INFO ");
+        expect(msg).toBe(" info logMsg ");
+        expect(foo).toBe(" foo=bar ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1=2");
+
+        const msg2 = capturedLogs[1][0];
+        let cookie;
+        [, info, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        expect(info).toBe("  INFO ");
+        expect(msg).toBe(" info nestedLogMsg ");
+        expect(foo).toBe(" foo.bar.baz=nested_msg ");
+        expect(cookie).toBe(" cookie.cutter=core ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1.two.foo=bar");
+    });
+
+    it("logs out debug msgs", () => {
+        const logger = new ConsoleLogger();
+        logger.debug("debug logMsg", logMsg);
+        logger.debug("debug nestedLogMsg", nestedLogMsg);
+        const msg1 = capturedLogs[0][0];
+        let [, debug, msg, foo, cc, file, arr1, arr2] = msg1.split("|");
+        expect(debug).toBe(" DEBUG ");
+        expect(msg).toBe(" debug logMsg ");
+        expect(foo).toBe(" foo=bar ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1=2");
+
+        const msg2 = capturedLogs[1][0];
+        let cookie;
+        [, debug, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        expect(debug).toBe(" DEBUG ");
+        expect(msg).toBe(" debug nestedLogMsg ");
+        expect(foo).toBe(" foo.bar.baz=nested_msg ");
+        expect(cookie).toBe(" cookie.cutter=core ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1.two.foo=bar");
+    });
+
+    it("logs out warn msgs", () => {
+        const logger = new ConsoleLogger();
+        logger.warn("warn logMsg", logMsg);
+        logger.warn("warn nestedLogMsg", nestedLogMsg);
+        const msg1 = capturedLogs[0][0];
+        let [, warn, msg, foo, cc, file, arr1, arr2] = msg1.split("|");
+        expect(warn).toBe("  WARN ");
+        expect(msg).toBe(" warn logMsg ");
+        expect(foo).toBe(" foo=bar ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1=2");
+
+        const msg2 = capturedLogs[1][0];
+        let cookie;
+        [, warn, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        expect(warn).toBe("  WARN ");
+        expect(msg).toBe(" warn nestedLogMsg ");
+        expect(foo).toBe(" foo.bar.baz=nested_msg ");
+        expect(cookie).toBe(" cookie.cutter=core ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1.two.foo=bar");
+    });
+
+    it("logs out error msgs", () => {
+        const logger = new ConsoleLogger();
+        logger.error("error logMsg", "unable to get data", logMsg);
+        logger.error("error nestedLogMsg", "unable to get data", nestedLogMsg);
+        const msg1 = capturedLogs[0][0];
+        let [, error, msg, foo, cc, file, arr1, arr2] = msg1.split("|");
+        expect(error).toBe(" ERROR ");
+        expect(msg).toBe(" error logMsg ");
+        expect(foo).toBe(" foo=bar ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1=2");
+        const errMsg1 = capturedLogs[1][0];
+        expect(errMsg1).toBe("unable to get data");
+
+        const msg2 = capturedLogs[2][0];
+        let cookie;
+        [, error, msg, foo, cookie, cc, file, arr1, arr2] = msg2.split("|");
+        expect(error).toBe(" ERROR ");
+        expect(msg).toBe(" error nestedLogMsg ");
+        expect(foo).toBe(" foo.bar.baz=nested_msg ");
+        expect(cookie).toBe(" cookie.cutter=core ");
+        expect(cc).toBe(" cc=core ");
+        expect(file).toBe(" file=ConsoleLogger.test.ts ");
+        expect(arr1).toBe(" array.0=one ");
+        expect(arr2).toBe(" array.1.two.foo=bar");
+        const errMsg2 = capturedLogs[3][0];
+        expect(errMsg2).toBe("unable to get data");
+    });
+});

--- a/packages/core/src/defaults/ConsoleLogger.ts
+++ b/packages/core/src/defaults/ConsoleLogger.ts
@@ -6,9 +6,22 @@ LICENSE file in the root directory of this source tree.
 */
 
 import _ = require("lodash");
+import { isNullOrUndefined } from "util";
 import { ILogger, ILoggerStructuredData } from "../model";
 
+export interface IConsoleLoggerOptions {
+    // maxDepth has a default of 10 if nothing is set.
+    // any value <= -1 will be considered to be infinite.
+    maxDepth?: number;
+}
+
 export class ConsoleLogger implements ILogger {
+    private maxDepth: number;
+
+    public constructor(options?: IConsoleLoggerOptions) {
+        this.maxDepth = options && !isNullOrUndefined(options.maxDepth) ? options.maxDepth : 10;
+    }
+
     public info(message: string, data?: ILoggerStructuredData): void {
         this.log("INFO", message, data || {});
     }
@@ -25,11 +38,14 @@ export class ConsoleLogger implements ILogger {
         this.log("ERROR", message, data || {}, err);
     }
 
-    private flattenObj(data: any, parentKey: string): string {
+    private flattenObj(data: any, parentKey: string, maxDepth: number): string {
         return Object.keys(data).reduce((p, k) => {
             const key = parentKey ? `${parentKey}.${k}` : k;
+            if (maxDepth === 0) {
+                return `${p} | ${key}=${data[k]}`;
+            }
             if (_.isObject(data[k])) {
-                return `${p}${this.flattenObj(data[k], key)}`;
+                return `${p}${this.flattenObj(data[k], key, maxDepth - 1)}`;
             }
             return `${p} | ${key}=${data[k]}`;
         }, "");
@@ -38,7 +54,7 @@ export class ConsoleLogger implements ILogger {
     // tslint:disable:no-console
     private log(level: string, message: string, data: ILoggerStructuredData, err?: any): void {
         level = level.padStart(5, " ");
-        const structured = this.flattenObj(data, "");
+        const structured = this.flattenObj(data, "", this.maxDepth);
         const now = new Date().toISOString();
         console.log(`${now} | ${level} | ${message}${structured}`);
         if (err) {

--- a/packages/core/src/defaults/ConsoleLogger.ts
+++ b/packages/core/src/defaults/ConsoleLogger.ts
@@ -5,6 +5,7 @@ This source code is licensed under the Apache 2.0 license found in the
 LICENSE file in the root directory of this source tree.
 */
 
+import _ = require("lodash");
 import { ILogger, ILoggerStructuredData } from "../model";
 
 export class ConsoleLogger implements ILogger {
@@ -24,10 +25,20 @@ export class ConsoleLogger implements ILogger {
         this.log("ERROR", message, data || {}, err);
     }
 
+    private flattenObj(data: any, parentKey: string): string {
+        return Object.keys(data).reduce((p, k) => {
+            const key = parentKey ? `${parentKey}.${k}` : k;
+            if (_.isObject(data[k])) {
+                return `${p}${this.flattenObj(data[k], key)}`;
+            }
+            return `${p} | ${key}=${data[k]}`;
+        }, "");
+    }
+
     // tslint:disable:no-console
     private log(level: string, message: string, data: ILoggerStructuredData, err?: any): void {
         level = level.padStart(5, " ");
-        const structured = Object.keys(data).reduce((p, k) => `${p} | ${k}=${data[k]}`, "");
+        const structured = this.flattenObj(data, "");
         const now = new Date().toISOString();
         console.log(`${now} | ${level} | ${message}${structured}`);
         if (err) {


### PR DESCRIPTION
The console logger renders out `[object Object]` if a field is an object so destructure it into `.` delimited nested fields (e.g. foo.bar.baz)