### PR TITLE
Add preprocessor concept for Azure Queues to support messages not following the envelope format

### DIFF
--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -14,7 +14,6 @@
     },
     "dependencies": {
         "@azure/cosmos": "3.4.2",
-        "@types/node": "^13.7.1",
         "azure-storage": "2.10.3",
         "lodash": "4.17.15",
         "opentracing": "0.14.4",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -14,7 +14,6 @@
     },
     "dependencies": {
         "@azure/cosmos": "3.4.2",
-        "@types/jest": "^25.1.2",
         "@types/node": "^13.7.1",
         "azure-storage": "2.10.3",
         "lodash": "4.17.15",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@azure/cosmos": "3.4.2",
+        "@types/jest": "^25.1.2",
         "@types/node": "^13.7.1",
         "azure-storage": "2.10.3",
         "lodash": "4.17.15",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-azure",
-    "version": "1.2.0-beta.10",
+    "version": "1.2.0-beta.11",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@azure/cosmos": "3.4.2",
+        "@types/node": "^13.7.1",
         "azure-storage": "2.10.3",
         "lodash": "4.17.15",
         "opentracing": "0.14.4",

--- a/packages/azure/src/streaming/index.ts
+++ b/packages/azure/src/streaming/index.ts
@@ -13,11 +13,10 @@ import {
     IOutputSink,
     IPublishedMessage,
 } from "@walmartlabs/cookie-cutter-core";
-import { QueueMessageEncoder } from "azure-storage";
 import { ICosmosConfiguration } from "..";
 import { CosmosConfiguration } from "../config";
 import { CosmosMessageDeduper } from "../event-sourced/internal";
-import { CosmosClient } from "../utils";
+import { CosmosClient, IQueueMessage } from "../utils";
 import {
     CosmosOutputSink,
     QueueConfiguration,
@@ -30,7 +29,7 @@ export interface IQueueConfiguration {
     readonly storageAccount: string;
     readonly storageAccessKey: string;
     readonly queueName: string;
-    readonly queueMessageEncoder?: QueueMessageEncoder;
+    readonly preprocessor?: IQueueMessagePreprocessor;
     readonly retryCount?: number;
     readonly retryInterval?: number;
     readonly encoder: IMessageEncoder;
@@ -80,6 +79,10 @@ export function queueSink(configuration: IQueueConfiguration): IOutputSink<IPubl
         largeItemBlobContainer: "queue-large-items",
     });
     return new QueueOutputSink(configuration);
+}
+
+export interface IQueueMessagePreprocessor {
+    process(msg: IQueueMessage): IQueueMessage;
 }
 
 export function queueSource(

--- a/packages/azure/src/streaming/index.ts
+++ b/packages/azure/src/streaming/index.ts
@@ -94,7 +94,12 @@ export function queueSource(
         largeItemBlobContainer: "queue-large-items",
         createQueueIfNotExists: false,
         preprocessor: {
-            process: (msg) => msg,
+            process: (msg) => {
+                return JSON.parse(msg.messageText) as {
+                    headers: Record<string, string>;
+                    payload: unknown;
+                };
+            },
         },
     });
     return new QueueInputSource(configuration);

--- a/packages/azure/src/streaming/index.ts
+++ b/packages/azure/src/streaming/index.ts
@@ -93,6 +93,9 @@ export function queueSource(
         retryInterval: 5000,
         largeItemBlobContainer: "queue-large-items",
         createQueueIfNotExists: false,
+        preprocessor: {
+            process: (msg) => msg,
+        },
     });
     return new QueueInputSource(configuration);
 }

--- a/packages/azure/src/streaming/index.ts
+++ b/packages/azure/src/streaming/index.ts
@@ -13,6 +13,7 @@ import {
     IOutputSink,
     IPublishedMessage,
 } from "@walmartlabs/cookie-cutter-core";
+import { QueueMessageEncoder } from "azure-storage";
 import { ICosmosConfiguration } from "..";
 import { CosmosConfiguration } from "../config";
 import { CosmosMessageDeduper } from "../event-sourced/internal";
@@ -29,6 +30,7 @@ export interface IQueueConfiguration {
     readonly storageAccount: string;
     readonly storageAccessKey: string;
     readonly queueName: string;
+    readonly queueMessageEncoder?: QueueMessageEncoder;
     readonly retryCount?: number;
     readonly retryInterval?: number;
     readonly encoder: IMessageEncoder;

--- a/packages/azure/src/streaming/internal/QueueInputSource.ts
+++ b/packages/azure/src/streaming/internal/QueueInputSource.ts
@@ -17,6 +17,7 @@ import {
     IRequireInitialization,
     isEmbeddable,
     MessageRef,
+    DefaultComponentContext,
 } from "@walmartlabs/cookie-cutter-core";
 import { FORMAT_HTTP_HEADERS, Tags, Tracer } from "opentracing";
 import { isArray } from "util";
@@ -53,6 +54,9 @@ export class QueueInputSource implements IInputSource, IRequireInitialization {
         this.client = QueueClientWithLargeItemSupport.create(config);
         this.readOptions = config;
         this.encoder = config.encoder;
+        this.metrics = DefaultComponentContext.metrics;
+        this.tracer = DefaultComponentContext.tracer;
+        this.logger = DefaultComponentContext.logger;
     }
 
     public async initialize(context: IComponentContext): Promise<void> {

--- a/packages/azure/src/streaming/internal/config.ts
+++ b/packages/azure/src/streaming/internal/config.ts
@@ -6,8 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 
 import { config, IMessageEncoder } from "@walmartlabs/cookie-cutter-core";
-import { QueueMessageEncoder } from "azure-storage";
-import { IQueueConfiguration, IQueueSourceConfiguration } from "..";
+import { IQueueConfiguration, IQueueSourceConfiguration, IQueueMessagePreprocessor } from "..";
 
 @config.section
 export class QueueConfiguration implements IQueueConfiguration {
@@ -36,10 +35,10 @@ export class QueueConfiguration implements IQueueConfiguration {
     }
     
     @config.field(config.converters.none)
-    public set queueMessageEncoder(_: QueueMessageEncoder) {
+    public set preprocessor(_: IQueueMessagePreprocessor) {
         config.noop();
     }
-    public get queueMessageEncoder(): QueueMessageEncoder {
+    public get preprocessor(): IQueueMessagePreprocessor {
         return config.noop();
     }
 

--- a/packages/azure/src/streaming/internal/config.ts
+++ b/packages/azure/src/streaming/internal/config.ts
@@ -6,6 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 
 import { config, IMessageEncoder } from "@walmartlabs/cookie-cutter-core";
+import { QueueMessageEncoder } from "azure-storage";
 import { IQueueConfiguration, IQueueSourceConfiguration } from "..";
 
 @config.section
@@ -31,6 +32,14 @@ export class QueueConfiguration implements IQueueConfiguration {
         config.noop();
     }
     public get queueName(): string {
+        return config.noop();
+    }
+    
+    @config.field(config.converters.none)
+    public set queueMessageEncoder(_: QueueMessageEncoder) {
+        config.noop();
+    }
+    public get queueMessageEncoder(): QueueMessageEncoder {
         return config.noop();
     }
 

--- a/packages/azure/src/utils/QueueClient.ts
+++ b/packages/azure/src/utils/QueueClient.ts
@@ -317,9 +317,7 @@ export class QueueClient implements IRequireInitialization {
                         );
                         resolve(
                             results.reduce((messages, result) => {
-                                const mesageObj = this.config.preprocessor.process(
-                                    result
-                                ) as IQueueMessage;
+                                const mesageObj = this.config.preprocessor.process(result);
 
                                 if (
                                     !mesageObj.headers ||

--- a/packages/azure/src/utils/QueueClient.ts
+++ b/packages/azure/src/utils/QueueClient.ts
@@ -101,6 +101,7 @@ export class QueueClient implements IRequireInitialization {
         this.defaultQueue = config.queueName;
         this.tracer = DefaultComponentContext.tracer;
         this.metrics = DefaultComponentContext.metrics;
+        this.logger = DefaultComponentContext.logger;
 
         const { retryCount, retryInterval } = config;
         this.queueService = createQueueService(config.storageAccount, config.storageAccessKey);

--- a/packages/azure/src/utils/QueueClient.ts
+++ b/packages/azure/src/utils/QueueClient.ts
@@ -320,10 +320,13 @@ export class QueueClient implements IRequireInitialization {
                                     payload: unknown;
                                 };
 
-                                if (!mesageObj.headers && !mesageObj.payload) {
+                                if (!mesageObj.headers) {
                                     mesageObj.headers = {
                                         [EventSourcedMetadata.EventType]: "unknown",
                                     };
+                                }
+
+                                if (!mesageObj.payload) {
                                     mesageObj.payload = {
                                         type: "Buffer",
                                         data: Buffer.from(result.messageText),


### PR DESCRIPTION
This PR is to start a conversation around how to allow us to consume any message from the azure storage queue.  This will hopefully resolve 2 issues:
1.  Message text is Base64 encoded and thus fails JSON.parse call.  We need to be able to specify QueueMessageEncoder for QueueService.messageEncoder

2. Messages may not have header and payload, so in this case need a generic header with messageText as the payload.