### PR TITLE
core: support multiple concurrent writers for BoundedPriorityQueue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
It's possible to get into a state where we've hit our limit on items
that we can add to the bounded priority queue and a large backlog of
items are accumulated. Once we can begin to process that backlog after
a `whenNotFull` promise resolves, the first item in the backlog will
create a new `whenNotFull` and proceed to await it. Subsequent items in
backlog queue will do the same but overwrite the promise of the first
item leading to a chain of promises for backlogged items that are
unresolvable. This PR ensures that we never overwrite the
`whenNotFull` promise for backlogged queue items and we can resolve
them all eventually.