### PR TITLE
core: unable to close bounded priority queue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/utils/BoundedPriorityQueue.test.ts
+++ b/packages/core/src/__test__/utils/BoundedPriorityQueue.test.ts
@@ -115,4 +115,13 @@ describe("BoundedPriorityQueue", () => {
         await Promise.all(enqueuePromises);
         expect(buffer).toMatchObject([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     });
+
+    it("closes queue immediately after it becomes empty", async () => {
+        const queue = new BoundedPriorityQueue<number>(1);
+        const enqueuePromise = queue.enqueue(1);
+        const dequeuePromise = queue.dequeue();
+        expect(() => queue.close()).not.toThrowError();
+        await enqueuePromise;
+        await dequeuePromise;
+    });
 });

--- a/packages/core/src/utils/BoundedPriorityQueue.ts
+++ b/packages/core/src/utils/BoundedPriorityQueue.ts
@@ -105,7 +105,9 @@ export class BoundedPriorityQueue<T> {
         if (this.whenNotEmpty) {
             this.whenNotEmpty.resolve();
         }
-        this.whenNotFull.resolve();
+        if (this.whenNotFull) {
+            this.whenNotFull.resolve();
+        }
     }
 
     public async *iterate(): AsyncIterableIterator<T> {


### PR DESCRIPTION
    core: fix issue with bounded priority queue not correctly supporting closing of queues
    immediately after it was drained leading to potential `Cannot read
    property 'resolve' of undefined` errors due to whenNotFull being
    undefined.
