### PR TITLE
multi cosmos collections (#81)

### DIFF
--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-azure",
-    "version": "1.3.0-beta.3",
+    "version": "1.3.0-beta.4",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/azure/src/__test__/event-sourced/internal/CosmosStateAggregationSource.test.ts
+++ b/packages/azure/src/__test__/event-sourced/internal/CosmosStateAggregationSource.test.ts
@@ -22,7 +22,7 @@ describe("CosmosStateAggregationSource", () => {
     interface ITestSetup {
         readonly source: CosmosStateAggregationSource<any>;
         readonly logSpy: jest.SpyInstance<void, []>;
-        readonly querySpy: jest.SpyInstance<Promise<any[]>, [SpanContext, ICosmosQuery]>;
+        readonly querySpy: jest.SpyInstance<Promise<any[]>, [SpanContext, ICosmosQuery, string?]>;
         readonly snapshotSpy: jest.SpyInstance<
             Promise<[number, any]>,
             [SpanContext, string, number?]

--- a/packages/azure/src/__test__/materialized/internal/MaterializedView.integration.test.ts
+++ b/packages/azure/src/__test__/materialized/internal/MaterializedView.integration.test.ts
@@ -196,7 +196,7 @@ describe.skip("Materialized Views", () => {
             );
 
             const state = new CosmosStateProvider(DummyState, client, new JsonMessageEncoder());
-            const stateRef = await state.get(undefined, `unknown/${streamId}`);
+            const stateRef = await state.get(undefined, `@unknown/${streamId}`);
             expect(stateRef).toMatchObject({
                 state: new DummyState(),
                 key: streamId,

--- a/packages/azure/src/__test__/utils/helpers.test.ts
+++ b/packages/azure/src/__test__/utils/helpers.test.ts
@@ -1,0 +1,19 @@
+import { getCollectionInfo } from "../../utils/helpers";
+
+describe("Collection Info helper test", () => {
+    it("correctly parses a collectionId and partition key", () => {
+        const test = "@collection/key";
+        const result: [string, string] = getCollectionInfo(test);
+
+        expect(result[0]).toBe("collection");
+        expect(result[1]).toBe("key");
+    });
+
+    it("correctly parses a partition key with no collection", () => {
+        const test = "key";
+        const result: [string, string] = getCollectionInfo(test);
+
+        expect(result[0]).toBe(undefined);
+        expect(result[1]).toBe("key");
+    });
+});

--- a/packages/azure/src/__test__/utils/helpers.test.ts
+++ b/packages/azure/src/__test__/utils/helpers.test.ts
@@ -17,6 +17,14 @@ describe("State Key Parsing", () => {
         expect(partitionKey).toBe("key");
     });
 
+    it("parses a state key with a state key in the @key format ", () => {
+        const inputKey = "@key";
+        const { collectionId, partitionKey } = getCollectionInfo(inputKey);
+
+        expect(collectionId).toBe(undefined);
+        expect(partitionKey).toBe("@key");
+    });
+
     it("parses a state key with an incorrectly formatted collectionId overwrite", () => {
         const inputKey = "collection/key";
         const { collectionId, partitionKey } = getCollectionInfo(inputKey);

--- a/packages/azure/src/__test__/utils/helpers.test.ts
+++ b/packages/azure/src/__test__/utils/helpers.test.ts
@@ -1,19 +1,27 @@
 import { getCollectionInfo } from "../../utils/helpers";
 
-describe("Collection Info helper test", () => {
-    it("correctly parses a collectionId and partition key", () => {
-        const test = "@collection/key";
-        const result: [string, string] = getCollectionInfo(test);
+describe("State Key Parsing", () => {
+    it("parses a state key with a collectionId overwrite", () => {
+        const inputKey = "@collection/key";
+        const { collectionId, partitionKey } = getCollectionInfo(inputKey);
 
-        expect(result[0]).toBe("collection");
-        expect(result[1]).toBe("key");
+        expect(collectionId).toBe("collection");
+        expect(partitionKey).toBe("key");
     });
 
-    it("correctly parses a partition key with no collection", () => {
-        const test = "key";
-        const result: [string, string] = getCollectionInfo(test);
+    it("parses a state key with no collectionId overwrite", () => {
+        const inputKey = "key";
+        const { collectionId, partitionKey } = getCollectionInfo(inputKey);
 
-        expect(result[0]).toBe(undefined);
-        expect(result[1]).toBe("key");
+        expect(collectionId).toBe(undefined);
+        expect(partitionKey).toBe("key");
+    });
+
+    it("parses a state key with an incorrectly formatted collectionId overwrite", () => {
+        const inputKey = "collection/key";
+        const { collectionId, partitionKey } = getCollectionInfo(inputKey);
+
+        expect(collectionId).toBe(undefined);
+        expect(partitionKey).toBe(undefined);
     });
 });

--- a/packages/azure/src/index.ts
+++ b/packages/azure/src/index.ts
@@ -42,7 +42,7 @@ export interface ICosmosQuery {
 }
 
 export interface ICosmosQueryClient {
-    query(spanContext: SpanContext, query: ICosmosQuery): Promise<any[]>;
+    query(spanContext: SpanContext, query: ICosmosQuery, collectionId?: string): Promise<any[]>;
 }
 
 export function cosmosQueryClient(configuration: ICosmosConfiguration): ICosmosQueryClient {

--- a/packages/azure/src/materialized/internal/CosmosStateProvider.ts
+++ b/packages/azure/src/materialized/internal/CosmosStateProvider.ts
@@ -48,9 +48,7 @@ export class CosmosStateProvider<TState extends IState<TSnapshot>, TSnapshot>
     }
 
     public async get(spanContext: SpanContext, key: string): Promise<StateRef<TState>> {
-        const collectionInfo: [string, string] = getCollectionInfo(key);
-        const collectionId = collectionInfo[0];
-        const partitionKey = collectionInfo[1];
+        const { collectionId, partitionKey } = getCollectionInfo(key);
 
         const result = await this.client.query(
             spanContext,

--- a/packages/azure/src/materialized/internal/CosmosStateProvider.ts
+++ b/packages/azure/src/materialized/internal/CosmosStateProvider.ts
@@ -24,6 +24,7 @@ import { SpanContext } from "opentracing";
 import { isNullOrUndefined } from "util";
 import { ICosmosQueryClient } from "../..";
 import { ICosmosDocument } from "../../utils";
+import { getCollectionId } from "../../utils/helpers";
 
 export class CosmosStateProvider<TState extends IState<TSnapshot>, TSnapshot>
     extends MaterializedViewStateProvider<TState, TSnapshot>
@@ -47,9 +48,6 @@ export class CosmosStateProvider<TState extends IState<TSnapshot>, TSnapshot>
     }
 
     public async get(spanContext: SpanContext, key: string): Promise<StateRef<TState>> {
-        const collectionInfo: string[] = key.split("/");
-        const collectionId = collectionInfo.length > 1 ? collectionInfo[0] : undefined;
-
         const result = await this.client.query(
             spanContext,
             {
@@ -57,7 +55,7 @@ export class CosmosStateProvider<TState extends IState<TSnapshot>, TSnapshot>
                         WHERE c.stream_id=@stream_id`,
                 parameters: [{ name: "@stream_id", value: key }],
             },
-            collectionId
+            getCollectionId(key)
         );
 
         if (result.length > 1) {

--- a/packages/azure/src/materialized/internal/CosmosStateProvider.ts
+++ b/packages/azure/src/materialized/internal/CosmosStateProvider.ts
@@ -47,11 +47,18 @@ export class CosmosStateProvider<TState extends IState<TSnapshot>, TSnapshot>
     }
 
     public async get(spanContext: SpanContext, key: string): Promise<StateRef<TState>> {
-        const result = await this.client.query(spanContext, {
-            query: `SELECT c.data, c.event_type, c.sn FROM c
-                    WHERE c.stream_id=@stream_id`,
-            parameters: [{ name: "@stream_id", value: key }],
-        });
+        const collectionInfo: string[] = key.split("/");
+        const collectionId = collectionInfo.length > 1 ? collectionInfo[0] : undefined;
+
+        const result = await this.client.query(
+            spanContext,
+            {
+                query: `SELECT c.data, c.event_type, c.sn FROM c
+                        WHERE c.stream_id=@stream_id`,
+                parameters: [{ name: "@stream_id", value: key }],
+            },
+            collectionId
+        );
 
         if (result.length > 1) {
             throw new Error(`found multiple documents for key '${key}', this is not expected`);

--- a/packages/azure/src/utils/CosmosClient.ts
+++ b/packages/azure/src/utils/CosmosClient.ts
@@ -310,13 +310,17 @@ export class CosmosClient
         partitionKey: string,
         validateSn: boolean
     ): Promise<void> {
+        const collectionInfo: [string, string] = getCollectionInfo(partitionKey);
+        const collectionId = collectionInfo[0];
+        const key = collectionInfo[1];
+
         if (documents && documents.length >= 1) {
             await this.executeSproc(
                 BULK_INSERT_SPROC_ID,
-                partitionKey,
+                key,
                 documents,
                 [documents, validateSn],
-                getCollectionInfo(partitionKey)
+                collectionId
             );
         }
     }

--- a/packages/azure/src/utils/CosmosClient.ts
+++ b/packages/azure/src/utils/CosmosClient.ts
@@ -31,7 +31,7 @@ import * as url from "url";
 import * as uuid from "uuid";
 import { isSequenceConflict } from ".";
 import { ICosmosConfiguration, ICosmosQuery, ICosmosQueryClient } from "..";
-import { getCollectionId } from "./helpers";
+import { getCollectionInfo } from "./helpers";
 
 export interface ICosmosWriteClient {
     upsert(
@@ -292,12 +292,16 @@ export class CosmosClient
     }
 
     public async upsert(document: any, partitionKey: string, currentSn: number): Promise<void> {
+        const collectionInfo: [string, string] = getCollectionInfo(partitionKey);
+        const collectionId = collectionInfo[0];
+        const key = collectionInfo[1];
+
         await this.executeSproc(
             UPSERT_SPROC_ID,
-            partitionKey,
+            key,
             [document],
             [document, currentSn],
-            getCollectionId(partitionKey)
+            collectionId
         );
     }
 
@@ -312,7 +316,7 @@ export class CosmosClient
                 partitionKey,
                 documents,
                 [documents, validateSn],
-                getCollectionId(partitionKey)
+                getCollectionInfo(partitionKey)
             );
         }
     }

--- a/packages/azure/src/utils/CosmosClient.ts
+++ b/packages/azure/src/utils/CosmosClient.ts
@@ -31,10 +31,21 @@ import * as url from "url";
 import * as uuid from "uuid";
 import { isSequenceConflict } from ".";
 import { ICosmosConfiguration, ICosmosQuery, ICosmosQueryClient } from "..";
+import { getCollectionId } from "./helpers";
 
 export interface ICosmosWriteClient {
-    upsert(document: any, partitionKey: string, currentSn: number): Promise<void>;
-    bulkInsert(documents: any[], partitionKey: string, validateSn: boolean): Promise<void>;
+    upsert(
+        document: any,
+        partitionKey: string,
+        currentSn: number,
+        collectionId?: string
+    ): Promise<void>;
+    bulkInsert(
+        documents: any[],
+        partitionKey: string,
+        validateSn: boolean,
+        collectionId?: string
+    ): Promise<void>;
 }
 
 enum CosmosMetrics {
@@ -139,7 +150,7 @@ export class CosmosClient
             .container(collectionId ?? this.config.collectionId);
     }
 
-    private async initializeStoredProcedure(sprocID: string): Promise<void> {
+    private async initializeStoredProcedure(sprocID: string, collectionId?: string): Promise<void> {
         const sprocPath = SPROCS.get(sprocID);
         if (!sprocPath) {
             throw new Error(
@@ -149,7 +160,7 @@ export class CosmosClient
 
         const file = fs.readFileSync(path.resolve(__dirname, sprocPath));
         const sprocBody = file.toString();
-        const container = await this.container();
+        const container = await this.container(collectionId);
         const query = {
             query: "SELECT * FROM collection c WHERE c.id = @id",
             parameters: [{ name: "@id", value: sprocID }],
@@ -219,14 +230,15 @@ export class CosmosClient
         sprocID: string,
         partitionKey: string,
         documents: any[],
-        parameters: any[]
+        parameters: any[],
+        collectionId?: string
     ): Promise<void> {
         const spans: Span[] = [];
         let requestCharge = 0;
         try {
-            const container = await this.container();
+            const container = await this.container(collectionId);
             if (!this.spInitialized.get(sprocID)) {
-                throw new Error(`Stored Procedure wasn't correctly registered - id: ${sprocID}`);
+                await this.initializeStoredProcedure(sprocID, collectionId);
             }
             let docTraceId = uuid.v4();
             for (const doc of documents) {
@@ -280,7 +292,13 @@ export class CosmosClient
     }
 
     public async upsert(document: any, partitionKey: string, currentSn: number): Promise<void> {
-        await this.executeSproc(UPSERT_SPROC_ID, partitionKey, [document], [document, currentSn]);
+        await this.executeSproc(
+            UPSERT_SPROC_ID,
+            partitionKey,
+            [document],
+            [document, currentSn],
+            getCollectionId(partitionKey)
+        );
     }
 
     public async bulkInsert(
@@ -289,10 +307,13 @@ export class CosmosClient
         validateSn: boolean
     ): Promise<void> {
         if (documents && documents.length >= 1) {
-            await this.executeSproc(BULK_INSERT_SPROC_ID, partitionKey, documents, [
+            await this.executeSproc(
+                BULK_INSERT_SPROC_ID,
+                partitionKey,
                 documents,
-                validateSn,
-            ]);
+                [documents, validateSn],
+                getCollectionId(partitionKey)
+            );
         }
     }
 

--- a/packages/azure/src/utils/CosmosClient.ts
+++ b/packages/azure/src/utils/CosmosClient.ts
@@ -133,10 +133,10 @@ export class CosmosClient
         }
     }
 
-    private async container(): Promise<Container> {
+    private async container(collectionId?: string): Promise<Container> {
         return await this.client
             .database(this.config.databaseId)
-            .container(this.config.collectionId);
+            .container(collectionId ?? this.config.collectionId);
     }
 
     private async initializeStoredProcedure(sprocID: string): Promise<void> {
@@ -296,12 +296,16 @@ export class CosmosClient
         }
     }
 
-    public async query(spanContext: SpanContext, query: ICosmosQuery): Promise<any[]> {
+    public async query(
+        spanContext: SpanContext,
+        query: ICosmosQuery,
+        collectionId?: string
+    ): Promise<any[]> {
         const span = this.tracer.startSpan(this.spanOperationName, { childOf: spanContext });
         this.spanLogAndSetTags(span, this.query.name, undefined, query.query);
         let requestCharge = 0;
         try {
-            const container = await this.container();
+            const container = await this.container(collectionId);
             const iterator = container.items.query(query, {
                 populateQueryMetrics: true,
             });

--- a/packages/azure/src/utils/CosmosClient.ts
+++ b/packages/azure/src/utils/CosmosClient.ts
@@ -291,33 +291,25 @@ export class CosmosClient
         }
     }
 
-    public async upsert(document: any, partitionKey: string, currentSn: number): Promise<void> {
-        const collectionInfo: [string, string] = getCollectionInfo(partitionKey);
-        const collectionId = collectionInfo[0];
-        const key = collectionInfo[1];
+    public async upsert(document: any, key: string, currentSn: number): Promise<void> {
+        const { collectionId, partitionKey } = getCollectionInfo(key);
 
         await this.executeSproc(
             UPSERT_SPROC_ID,
-            key,
+            partitionKey,
             [document],
             [document, currentSn],
             collectionId
         );
     }
 
-    public async bulkInsert(
-        documents: any[],
-        partitionKey: string,
-        validateSn: boolean
-    ): Promise<void> {
-        const collectionInfo: [string, string] = getCollectionInfo(partitionKey);
-        const collectionId = collectionInfo[0];
-        const key = collectionInfo[1];
+    public async bulkInsert(documents: any[], key: string, validateSn: boolean): Promise<void> {
+        const { collectionId, partitionKey } = getCollectionInfo(key);
 
         if (documents && documents.length >= 1) {
             await this.executeSproc(
                 BULK_INSERT_SPROC_ID,
-                key,
+                partitionKey,
                 documents,
                 [documents, validateSn],
                 collectionId

--- a/packages/azure/src/utils/helpers.ts
+++ b/packages/azure/src/utils/helpers.ts
@@ -14,7 +14,7 @@ export function getCollectionInfo(key: string): { collectionId?: string; partiti
     let collectionId: string;
     let partitionKey: string;
 
-    if (collectionInfo.length === 1 && !collectionInfo[0].startsWith("@")) {
+    if (collectionInfo.length === 1) {
         partitionKey = collectionInfo[0];
         return { collectionId, partitionKey };
     }

--- a/packages/azure/src/utils/helpers.ts
+++ b/packages/azure/src/utils/helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns a collectionId from a provided key. If the key is not in the expected format,
+ * undefined is returned
+ * @param key A key in the format @collection/partitionKey
+ */
+export function getCollectionId(key: string): string | undefined {
+    const collectionInfo: string[] = key.split("/");
+    return collectionInfo.length === 1 ? collectionInfo[0].replace("@", "") : undefined;
+}

--- a/packages/azure/src/utils/helpers.ts
+++ b/packages/azure/src/utils/helpers.ts
@@ -3,7 +3,9 @@
  * undefined is returned
  * @param key A key in the format @collection/partitionKey
  */
-export function getCollectionId(key: string): string | undefined {
+export function getCollectionInfo(key: string): [string, string] {
     const collectionInfo: string[] = key.split("/");
-    return collectionInfo.length === 1 ? collectionInfo[0].replace("@", "") : undefined;
+    return collectionInfo.length === 2
+        ? [collectionInfo[0].replace("@", ""), collectionInfo[1]]
+        : [undefined, key];
 }

--- a/packages/azure/src/utils/helpers.ts
+++ b/packages/azure/src/utils/helpers.ts
@@ -1,11 +1,29 @@
 /**
- * Returns a collectionId from a provided key. If the key is not in the expected format,
- * undefined is returned
- * @param key A key in the format @collection/partitionKey
+ * Returns a collectionId and partitionKey from a provided state key. If the input is not in the expected format,
+ * undefined is returned.
+ *
+ * Only the following inputs are acceptable:
+ *  - "partitionKey"
+ *  - "@collection/partitionKey"
+ *
+ * @param inputKey A state key in the format @collectionId/partitionKey
  */
-export function getCollectionInfo(key: string): [string, string] {
+export function getCollectionInfo(key: string): { collectionId?: string; partitionKey: string } {
     const collectionInfo: string[] = key.split("/");
-    return collectionInfo.length === 2
-        ? [collectionInfo[0].replace("@", ""), collectionInfo[1]]
-        : [undefined, key];
+
+    let collectionId: string;
+    let partitionKey: string;
+
+    if (collectionInfo.length === 1 && !collectionInfo[0].startsWith("@")) {
+        partitionKey = collectionInfo[0];
+        return { collectionId, partitionKey };
+    }
+
+    if (collectionInfo.length !== 2 || !collectionInfo[0].startsWith("@")) {
+        return { collectionId, partitionKey };
+    } else {
+        collectionId = collectionInfo[0].replace("@", "");
+        partitionKey = collectionInfo[1];
+        return { collectionId, partitionKey };
+    }
 }


### PR DESCRIPTION
Adds support for multiple cosmos collections
 - keys must be provided in the format  "@collection/key" or "key"
 - collectionIds are optional