### PR TITLE
Fix breaking API change in Azure Queues

### DIFF
--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-azure",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/azure/src/streaming/index.ts
+++ b/packages/azure/src/streaming/index.ts
@@ -56,8 +56,8 @@ export interface IQueueSourceConfiguration {
     numOfMessages?: number;
 
     /**
-     * Required if not peek only. Specifies the new visibility timeout value, in milliseconds,
-     * relative to server time. The new value must be larger than or equal to 0, and cannot be larger than 7 days (604800000 milliseconds).
+     * Required if not peek only. Specifies the new visibility timeout value, in seconds,
+     * relative to server time. The new value must be larger than or equal to 0, and cannot be larger than 7 days (604800 seconds).
      * The visibility timeout of a message can be set to a value later than the expiry time.
      */
     visibilityTimeout?: number;

--- a/packages/azure/src/streaming/internal/config.ts
+++ b/packages/azure/src/streaming/internal/config.ts
@@ -102,7 +102,12 @@ export class QueueSourceConfiguration extends QueueConfiguration
         return config.noop();
     }
 
-    @config.field(config.converters.timespanOf(config.TimeSpanTargetUnit.Seconds))
+    @config.field(
+        config.converters.timespanOf(
+            config.TimeSpanTargetUnit.Seconds,
+            config.TimeSpanTargetUnit.Seconds
+        )
+    )
     public set visibilityTimeout(_: number) {
         config.noop();
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/config.test.ts
+++ b/packages/core/src/__test__/config.test.ts
@@ -104,6 +104,96 @@ describe("Primitive Values", () => {
         }
     }
 
+    interface ITimes {
+        readonly millisecondsToDays?: number;
+        readonly hoursToSeconds?: number;
+        readonly minutesToHours?: number;
+        readonly millisecondsToMinutes?: number;
+        readonly hoursToMinutes?: number;
+        readonly secondsToSeconds?: number;
+    }
+
+    @config.section
+    class Times implements ITimes {
+        @config.field(
+            config.converters.timespanOf(
+                config.TimeSpanTargetUnit.Days,
+                config.TimeSpanTargetUnit.Milliseconds
+            )
+        )
+        public get millisecondsToDays(): number {
+            return config.noop();
+        }
+        public set millisecondsToDays(_: number) {
+            config.noop();
+        }
+
+        @config.field(
+            config.converters.timespanOf(
+                config.TimeSpanTargetUnit.Seconds,
+                config.TimeSpanTargetUnit.Hours
+            )
+        )
+        public get hoursToSeconds(): number {
+            return config.noop();
+        }
+        public set hoursToSeconds(_: number) {
+            config.noop();
+        }
+
+        @config.field(
+            config.converters.timespanOf(
+                config.TimeSpanTargetUnit.Hours,
+                config.TimeSpanTargetUnit.Minutes
+            )
+        )
+        public get minutesToHours(): number {
+            return config.noop();
+        }
+        public set minutesToHours(_: number) {
+            config.noop();
+        }
+
+        @config.field(
+            config.converters.timespanOf(
+                config.TimeSpanTargetUnit.Minutes,
+                config.TimeSpanTargetUnit.Milliseconds
+            )
+        )
+        public get millisecondsToMinutes(): number {
+            return config.noop();
+        }
+        public set millisecondsToMinutes(_: number) {
+            config.noop();
+        }
+
+        @config.field(
+            config.converters.timespanOf(
+                config.TimeSpanTargetUnit.Minutes,
+                config.TimeSpanTargetUnit.Hours
+            )
+        )
+        public get hoursToMinutes(): number {
+            return config.noop();
+        }
+        public set hoursToMinutes(_: number) {
+            config.noop();
+        }
+
+        @config.field(
+            config.converters.timespanOf(
+                config.TimeSpanTargetUnit.Seconds,
+                config.TimeSpanTargetUnit.Seconds
+            )
+        )
+        public get secondsToSeconds(): number {
+            return config.noop();
+        }
+        public set secondsToSeconds(_: number) {
+            config.noop();
+        }
+    }
+
     it("parses empty object", () => {
         const actual = config.parse(Config, {}, {});
         expect(actual.str).toBeUndefined();
@@ -221,6 +311,36 @@ describe("Primitive Values", () => {
             expect(actual.timeout).toBe(c[1]);
             expect(actual.timeout2).toBe(c[1] && (c[1] as number) / 1000);
         }
+    });
+
+    it("converts timespan -> number with different target and source units", () => {
+        const tester = {
+            msToD: [2 * 24 * 60 * 60 * 1000, 2],
+            hToS: [1, 60 * 60],
+            mToH: [3 * 60, 3],
+            msToM: [2 * 60 * 1000, 2],
+            hToM: [2.5, 2.5 * 60],
+            sToS: [13, 13],
+        };
+        const actual = config.parse(
+            Times,
+            {
+                millisecondsToDays: tester.msToD[0],
+                hoursToSeconds: tester.hToS[0],
+                minutesToHours: tester.mToH[0],
+                millisecondsToMinutes: tester.msToM[0],
+                hoursToMinutes: tester.hToM[0],
+                secondsToSeconds: tester.sToS[0],
+            },
+            {}
+        );
+
+        expect(actual.millisecondsToDays).toBe(tester.msToD[1]);
+        expect(actual.hoursToSeconds).toBe(tester.hToS[1]);
+        expect(actual.minutesToHours).toBe(tester.mToH[1]);
+        expect(actual.millisecondsToMinutes).toBe(tester.msToM[1]);
+        expect(actual.hoursToMinutes).toBe(tester.hToM[1]);
+        expect(actual.secondsToSeconds).toBe(tester.sToS[1]);
     });
 
     it("converts string -> numeric enum", () => {

--- a/packages/core/src/__test__/config.test.ts
+++ b/packages/core/src/__test__/config.test.ts
@@ -314,33 +314,32 @@ describe("Primitive Values", () => {
     });
 
     it("converts timespan -> number with different target and source units", () => {
-        const tester = {
-            msToD: [2 * 24 * 60 * 60 * 1000, 2],
-            hToS: [1, 60 * 60],
-            mToH: [3 * 60, 3],
-            msToM: [2 * 60 * 1000, 2],
-            hToM: [2.5, 2.5 * 60],
-            sToS: [13, 13],
+        const input: ITimes = {
+            millisecondsToDays: 2 * 24 * 60 * 60 * 1000,
+            hoursToSeconds: 1,
+            minutesToHours: 3 * 60,
+            millisecondsToMinutes: 2 * 60 * 1000,
+            hoursToMinutes: 2.5,
+            secondsToSeconds: 13,
         };
-        const actual = config.parse(
-            Times,
-            {
-                millisecondsToDays: tester.msToD[0],
-                hoursToSeconds: tester.hToS[0],
-                minutesToHours: tester.mToH[0],
-                millisecondsToMinutes: tester.msToM[0],
-                hoursToMinutes: tester.hToM[0],
-                secondsToSeconds: tester.sToS[0],
-            },
-            {}
-        );
 
-        expect(actual.millisecondsToDays).toBe(tester.msToD[1]);
-        expect(actual.hoursToSeconds).toBe(tester.hToS[1]);
-        expect(actual.minutesToHours).toBe(tester.mToH[1]);
-        expect(actual.millisecondsToMinutes).toBe(tester.msToM[1]);
-        expect(actual.hoursToMinutes).toBe(tester.hToM[1]);
-        expect(actual.secondsToSeconds).toBe(tester.sToS[1]);
+        const expected: ITimes = {
+            millisecondsToDays: 2,
+            hoursToSeconds: 60 * 60,
+            minutesToHours: 3,
+            millisecondsToMinutes: 2,
+            hoursToMinutes: 2.5 * 60,
+            secondsToSeconds: 13,
+        };
+
+        const actual = config.parse(Times, input, {});
+
+        expect(actual.millisecondsToDays).toBe(expected.millisecondsToDays);
+        expect(actual.hoursToSeconds).toBe(expected.hoursToSeconds);
+        expect(actual.minutesToHours).toBe(expected.minutesToHours);
+        expect(actual.millisecondsToMinutes).toBe(expected.millisecondsToMinutes);
+        expect(actual.hoursToMinutes).toBe(expected.hoursToMinutes);
+        expect(actual.secondsToSeconds).toBe(expected.secondsToSeconds);
     });
 
     it("converts string -> numeric enum", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -234,34 +234,51 @@ export const converters = {
         throw new Error(`unable to convert '${val}' of type '${typeof val}' to bytes`);
     },
     timespan: (val: any): any => converters.timespanOf(TimeSpanTargetUnit.Milliseconds)(val),
-    timespanOf: (target: TimeSpanTargetUnit): ValueConvertFn => {
+    timespanOf: (
+        target: TimeSpanTargetUnit,
+        source: TimeSpanTargetUnit = TimeSpanTargetUnit.Milliseconds
+    ): ValueConvertFn => {
         return function(val: any): any {
             if (isNullOrUndefined(val)) {
                 return val;
             }
 
-            let millis = 0;
+            if (target < TimeSpanTargetUnit.Milliseconds || target > TimeSpanTargetUnit.Days) {
+                throw new Error(`unknown target unit '${target}'`);
+            }
+
+            if (source < TimeSpanTargetUnit.Milliseconds || source > TimeSpanTargetUnit.Days) {
+                throw new Error(`unknown target unit '${source}'`);
+            }
+            //                         x  ms    s   m   h   d
+            const conversionFactors = [0, 1, 1000, 60, 60, 24];
+
+            let sourceTime = 0;
             if (isNumber(val)) {
-                millis = val;
+                sourceTime = val;
             } else if (isString(val)) {
-                millis = ms(val);
+                sourceTime = ms(val);
+                source = TimeSpanTargetUnit.Milliseconds;
             } else {
                 throw new Error(`unable to convert '${val}' of type '${typeof val}' to timespan`);
             }
 
-            switch (target) {
-                case TimeSpanTargetUnit.Milliseconds:
-                    return millis;
-                case TimeSpanTargetUnit.Seconds:
-                    return Math.floor(millis / 1000);
-                case TimeSpanTargetUnit.Minutes:
-                    return Math.floor(millis / 1000 / 60);
-                case TimeSpanTargetUnit.Hours:
-                    return Math.floor(millis / 1000 / 60 / 60);
-                case TimeSpanTargetUnit.Days:
-                    return Math.floor(millis / 1000 / 60 / 60 / 24);
-                default:
-                    throw new Error(`unknown target unit '${target}'`);
+            if (source === target) {
+                return sourceTime;
+            } else if (source > target) {
+                let convertedTime = sourceTime;
+                // skip the conversion factor for the smallest unit in the chain
+                for (let ii = target + 1; ii <= source; ii++) {
+                    convertedTime = convertedTime * conversionFactors[ii];
+                }
+                return convertedTime;
+            } else if (source < target) {
+                let convertedTime = sourceTime;
+                // skip the conversion factor for the smallest unit in the chain
+                for (let ii = source + 1; ii <= target; ii++) {
+                    convertedTime = convertedTime / conversionFactors[ii];
+                }
+                return Math.floor(convertedTime);
             }
         };
     },


### PR DESCRIPTION
The API contract of Azure Queue's was changed to accept milliseconds instead of seconds as part of a bugfix in 1.2. This PR reverts the breaking API change and restores semver compatibility.