### PR TITLE
ConcurrentMessageProcessor suppresses error details

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.3.0-beta.2",
+    "version": "1.3.0-beta.3",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -252,8 +252,6 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
             if (sequence % this.config.yieldForIOMessageCount === 0) {
                 await waitForPendingIO();
             }
-        } catch (e) {
-            throw e;
         } finally {
             if (dispatchError) {
                 if (handlingInputSpan) {

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -253,7 +253,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                 await waitForPendingIO();
             }
         } catch (e) {
-            throw new Error("failed to process message");
+            throw e;
         } finally {
             if (dispatchError) {
                 if (handlingInputSpan) {


### PR DESCRIPTION
When message handling fails outside of the message handler the ConcurrentMessageHandler currently throws a generic Error that hides the underlying root cause error. This PR changes it to re-throw the original error, similar to what the SerialMessageProcessor is doing.