### PR TITLE
Prevent BoundedPriorityQueue from deprioritizing waiting enqueue calls

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.3.0-beta.6",
+    "version": "1.3.0-beta.7",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/utils/BoundedPriorityQueue.test.ts
+++ b/packages/core/src/__test__/utils/BoundedPriorityQueue.test.ts
@@ -144,4 +144,22 @@ describe("BoundedPriorityQueue", () => {
         await enqueuePromise;
         await dequeuePromise;
     });
+
+    it("keeps priority through subsequent attempts to enqueue", async () => {
+        const queue = new BoundedPriorityQueue<number>(1);
+        await queue.enqueue(1, 0);
+        await queue.enqueue(2, 1);
+        queue.enqueue(3, 1);
+        queue.enqueue(4, 1);
+
+        const buffer = [];
+        for await (const item of queue.iterate()) {
+            buffer.push(item);
+            if (buffer.length === 4) {
+                queue.close();
+            }
+        }
+
+        expect(buffer).toMatchObject([2, 3, 4, 1]);
+    });
 });

--- a/packages/core/src/__test__/utils/BoundedPriorityQueue.test.ts
+++ b/packages/core/src/__test__/utils/BoundedPriorityQueue.test.ts
@@ -149,7 +149,9 @@ describe("BoundedPriorityQueue", () => {
         const queue = new BoundedPriorityQueue<number>(1);
         await queue.enqueue(1, 0);
         await queue.enqueue(2, 1);
+        // tslint:disable-next-line:no-floating-promises
         queue.enqueue(3, 1);
+        // tslint:disable-next-line:no-floating-promises
         queue.enqueue(4, 1);
 
         const buffer = [];

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -59,9 +59,10 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
     }
 
     protected reportStatistics() {
+        this.metrics.gauge(MessageProcessingMetrics.InputQueue, this.inputQueue.length);
         this.metrics.gauge(
-            MessageProcessingMetrics.InputQueue,
-            this.inputQueue.length + super.currentlyInflight.length
+            MessageProcessingMetrics.ConcurrentHandlers,
+            super.currentlyInflight.length
         );
         this.metrics.gauge(MessageProcessingMetrics.OutputQueue, this.outputQueue.length);
     }

--- a/packages/core/src/internal/processor/RpcMessageProcessor.ts
+++ b/packages/core/src/internal/processor/RpcMessageProcessor.ts
@@ -10,7 +10,6 @@ import {
     IMessageEnricher,
     IMessageMetricAnnotator,
     IServiceRegistry,
-    MessageProcessingMetrics,
     MessageRef,
 } from "../../model";
 import { IRetrier, sleep } from "../../utils";
@@ -28,14 +27,6 @@ export class RpcMessageProcessor extends ConcurrentMessageProcessor {
 
     protected get name(): string {
         return RpcMessageProcessor.name;
-    }
-
-    protected reportStatistics() {
-        super.reportStatistics();
-        this.metrics.gauge(
-            MessageProcessingMetrics.ConcurrentHandlers,
-            super.currentlyInflight.length
-        );
     }
 
     protected async processingLoop(

--- a/packages/core/src/utils/BoundedPriorityQueue.ts
+++ b/packages/core/src/utils/BoundedPriorityQueue.ts
@@ -64,7 +64,7 @@ export class BoundedPriorityQueue<T> {
         if (isNullOrUndefined(whenNotFull)) {
             this.whenNotFullList.set(priority, new Future());
         }
-        return this.enqueue(item);
+        return this.enqueue(item, priority);
     }
 
     public async dequeue(): Promise<T> {


### PR DESCRIPTION
Also move the in flight requests value into its own gauge for Concurrent parallelism mode. 