### PR TITLE
Change LogLevel from Error -> Warn when retrieving Kafka watermarks

### DIFF
--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kafka",
-    "version": "1.3.0-beta.2",
+    "version": "1.3.0-beta.3",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/kafka/src/KafkaConsumer.ts
+++ b/packages/kafka/src/KafkaConsumer.ts
@@ -408,7 +408,7 @@ export class KafkaConsumer implements IRequireInitialization, IDisposable {
                         }
                     }
                 } catch (e) {
-                    this.logger.error("Unable to retrieve watermarks", e);
+                    this.logger.warn("Unable to retrieve watermarks", e);
                 }
             }
         } finally {


### PR DESCRIPTION
watermarks are only loaded so they can be exposed as metrics. failure to do so has no effect on the message processing flow.