### PR TITLE
Ensure RedisClient's "type" metric label is always a string

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-redis",
-    "version": "1.3.0-beta.12",
+    "version": "1.3.0-beta.13",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Several public functions on RedisClient take a `type: string | IClassType<T>` but do not validate that the given `type` is a string before attempting to use it as a metric label. When using the Prometheus exporter I recently observed the following value for the "type" label on a service's `/metrics` endpoint:
```
# TYPE kepler_cookie_cutter_redis_client_get counter
kepler_cookie_cutter_redis_client_get{type="function DomainType(properties) {
                        this.domainArray1 = [];
                        this.domainArray2 = [];
                        if (properties)
                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                                if (properties[keys[i]] != null)
                                    this[keys[i]] = properties[keys[i]];
                    }",db="0",result="success"} 5951 1601386579347
```

The Cookie Cutter Prometheus package also logs the following warning when this happens:
```json
{"msg":"Prometheus Labels of Type other than string or number passed in","badLabels":["type"]}
```