### PR TITLE
Fix: pass string error message to metrics 

### DIFF
--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-gcp",
-    "version": "1.4.0-beta.0",
+    "version": "1.4.0-beta.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/gcp/src/BigQueryClient.ts
+++ b/packages/gcp/src/BigQueryClient.ts
@@ -81,7 +81,7 @@ export class BigQueryClient implements IBigQueryClient, IRequireInitialization {
             this.metrics.increment(BigQueryMetrics.Put, {
                 datasetTable,
                 result: BigQueryMetricResults.Error,
-                error: e,
+                error: e instanceof Error ? e.message : "",
             });
             throw e;
         } finally {

--- a/packages/gcp/src/GcsClient.ts
+++ b/packages/gcp/src/GcsClient.ts
@@ -77,7 +77,7 @@ export class GcsClient implements IGcsClient, IRequireInitialization {
             this.metrics.increment(GCSMetrics.Put, {
                 bucket,
                 result: GCSMetricResults.Error,
-                error: e,
+                error: e instanceof Error ? e.message : "",
             });
             throw e;
         } finally {


### PR DESCRIPTION
Currently the entire Error object is being passed to metrics. Change it to pass only the error string. 