### PR TITLE
[kafka] Expose compression settings for producers via kafkaSink

### DIFF
--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kafka",
-    "version": "1.4.0-beta.0",
+    "version": "1.4.0-beta.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/kafka/src/KafkaConsumer.ts
+++ b/packages/kafka/src/KafkaConsumer.ts
@@ -17,8 +17,6 @@ import {
 } from "@walmartlabs/cookie-cutter-core";
 import {
     Admin,
-    CompressionCodecs,
-    CompressionTypes,
     Consumer,
     ConsumerCrashEvent,
     ConsumerGroupJoinEvent,
@@ -30,8 +28,6 @@ import {
     RequestQueueSizeEvent,
     RetryOptions,
 } from "kafkajs";
-import * as LZ4Codec from "kafkajs-lz4";
-import * as SnappyCodec from "kafkajs-snappy";
 import Long = require("long");
 import { isNumber, isString } from "util";
 import {
@@ -43,10 +39,9 @@ import {
 } from ".";
 import { IMessageHeaders, IRawKafkaMessage } from "./model";
 import { OffsetManager } from "./OffsetManager";
-import { generateClientId } from "./utils";
+import { generateClientId, loadCompressionPlugins } from "./utils";
 
-CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
-CompressionCodecs[CompressionTypes.LZ4] = new (LZ4Codec as any)().codec;
+loadCompressionPlugins();
 
 enum KafkaMetrics {
     RequestQueueSize = "cookie_cutter.kafka_consumer.request_queue_size",

--- a/packages/kafka/src/KafkaMessageProducer.ts
+++ b/packages/kafka/src/KafkaMessageProducer.ts
@@ -13,8 +13,6 @@ import {
     OpenTracingTagKeys,
 } from "@walmartlabs/cookie-cutter-core";
 import * as kafkajs from "kafkajs";
-import * as LZ4Codec from "kafkajs-lz4";
-import * as SnappyCodec from "kafkajs-snappy";
 import { FORMAT_HTTP_HEADERS, Span, Tags, Tracer } from "opentracing";
 import * as uuid from "uuid";
 import {
@@ -23,9 +21,9 @@ import {
     KafkaPublisherCompressionMode,
 } from ".";
 import { IProducerMessage, TRACE_HEADER } from "./model";
+import { loadCompressionPlugins } from "./utils";
 
-kafkajs.CompressionCodecs[kafkajs.CompressionTypes.Snappy] = SnappyCodec;
-kafkajs.CompressionCodecs[kafkajs.CompressionTypes.LZ4] = new (LZ4Codec as any)().codec;
+loadCompressionPlugins();
 
 enum KafkaMetrics {
     MsgPublished = "cookie_cutter.kafka_producer.msg_published",

--- a/packages/kafka/src/KafkaMessageProducer.ts
+++ b/packages/kafka/src/KafkaMessageProducer.ts
@@ -13,6 +13,8 @@ import {
     OpenTracingTagKeys,
 } from "@walmartlabs/cookie-cutter-core";
 import * as kafkajs from "kafkajs";
+import * as LZ4Codec from "kafkajs-lz4";
+import * as SnappyCodec from "kafkajs-snappy";
 import { FORMAT_HTTP_HEADERS, Span, Tags, Tracer } from "opentracing";
 import * as uuid from "uuid";
 import {
@@ -21,6 +23,9 @@ import {
     KafkaPublisherCompressionMode,
 } from ".";
 import { IProducerMessage, TRACE_HEADER } from "./model";
+
+kafkajs.CompressionCodecs[kafkajs.CompressionTypes.Snappy] = SnappyCodec;
+kafkajs.CompressionCodecs[kafkajs.CompressionTypes.LZ4] = new (LZ4Codec as any)().codec;
 
 enum KafkaMetrics {
     MsgPublished = "cookie_cutter.kafka_producer.msg_published",
@@ -42,6 +47,10 @@ namespace CompressionTypes {
                 return kafkajs.CompressionTypes.None;
             case KafkaPublisherCompressionMode.Gzip:
                 return kafkajs.CompressionTypes.GZIP;
+            case KafkaPublisherCompressionMode.Snappy:
+                return kafkajs.CompressionTypes.Snappy;
+            case KafkaPublisherCompressionMode.LZ4:
+                return kafkajs.CompressionTypes.LZ4;
             default:
                 throw new Error("Unknown KafkaPublisherCompressionMode");
         }

--- a/packages/kafka/src/KafkaSink.ts
+++ b/packages/kafka/src/KafkaSink.ts
@@ -27,6 +27,7 @@ import {
     IKafkaPublisherConfiguration,
     KafkaMessagePublishingStrategy,
     KafkaMetadata,
+    KafkaPublisherCompressionMode,
 } from ".";
 import { KafkaMessageProducer } from "./KafkaMessageProducer";
 import { IOffsetTracker, IProducerMessage } from "./model";
@@ -106,6 +107,7 @@ export class KafkaSink
     public async sink(output: IterableIterator<IPublishedMessage>): Promise<void> {
         let sendWith: kafkajs.Producer | kafkajs.Transaction = this.producer;
         let transaction: kafkajs.Transaction;
+        const compressionMode = this.config.compressionMode ?? KafkaPublisherCompressionMode.None;
         let acks = 1; // Only leader
         const offsetTracker: IOffsetTracker = {};
 
@@ -152,7 +154,13 @@ export class KafkaSink
                 this.logMissingKey = false;
             }
             try {
-                await this.messageProducer.sendMessages(messages, topic, acks, sendWith);
+                await this.messageProducer.sendMessages(
+                    messages,
+                    topic,
+                    acks,
+                    sendWith,
+                    compressionMode
+                );
 
                 if (transaction && offsetTracker[topic]) {
                     // Send any offsets participating in transaction for this topic

--- a/packages/kafka/src/config.ts
+++ b/packages/kafka/src/config.ts
@@ -15,6 +15,7 @@ import {
     IKafkaTopic,
     KafkaMessagePublishingStrategy,
     KafkaOffsetResetStrategy,
+    KafkaPublisherCompressionMode,
 } from ".";
 
 @config.section
@@ -144,6 +145,14 @@ export class KafkaPublisherConfiguration extends KafkaBrokerConfiguration
         config.noop();
     }
     public get transactionalId(): string {
+        return config.noop();
+    }
+
+    @config.field(config.converters.enum(KafkaPublisherCompressionMode))
+    public set compressionMode(_: KafkaPublisherCompressionMode) {
+        config.noop();
+    }
+    public get compressionMode(): KafkaPublisherCompressionMode {
         return config.noop();
     }
 }

--- a/packages/kafka/src/index.ts
+++ b/packages/kafka/src/index.ts
@@ -98,8 +98,12 @@ export enum KafkaMessagePublishingStrategy {
 export enum KafkaPublisherCompressionMode {
     /** Messages will be published as-is without any compression. */
     None = 1,
-    /** Messages will be published after gzip-ing their payload. */
+    /** Messages will be compressed with the Gzip algorithm before being published. */
     Gzip,
+    /** Messages will be compressed with the Snappy algorithm before being published. */
+    Snappy,
+    /** Messages will be compressed with the LZ4 algorithm before being published. */
+    LZ4,
 }
 
 export interface IKafkaPublisherConfiguration {

--- a/packages/kafka/src/index.ts
+++ b/packages/kafka/src/index.ts
@@ -95,6 +95,13 @@ export enum KafkaMessagePublishingStrategy {
     ExactlyOnceSemantics,
 }
 
+export enum KafkaPublisherCompressionMode {
+    /** Messages will be published as-is without any compression. */
+    None = 1,
+    /** Messages will be published after gzip-ing their payload. */
+    Gzip,
+}
+
 export interface IKafkaPublisherConfiguration {
     readonly defaultTopic?: string;
     readonly maximumBatchSize?: number;
@@ -118,6 +125,11 @@ export interface IKafkaPublisherConfiguration {
      * > leak through the fencing provided by transactions.
      */
     readonly transactionalId?: string;
+    /**
+     * Determines which compression mode, if any, should be used to produce messages.
+     * Defaults to `None`.
+     */
+    readonly compressionMode?: KafkaPublisherCompressionMode;
 }
 
 export interface IKafkaTopic {
@@ -163,6 +175,7 @@ export function kafkaSink(
         messagePublishingStrategy: KafkaMessagePublishingStrategy.NonTransactional,
         maximumBatchSize: 1000,
         headerNames: DefaultKafkaHeaderNames,
+        compressionMode: KafkaPublisherCompressionMode.None,
     });
     return new KafkaSink(configuration);
 }

--- a/packages/kafka/src/utils.ts
+++ b/packages/kafka/src/utils.ts
@@ -6,8 +6,16 @@ LICENSE file in the root directory of this source tree.
 */
 
 import { getRootProjectPackageInfo } from "@walmartlabs/cookie-cutter-core";
+import { CompressionCodecs, CompressionTypes } from "kafkajs";
+import * as LZ4Codec from "kafkajs-lz4";
+import * as SnappyCodec from "kafkajs-snappy";
 import * as uuid from "uuid";
 
 export function generateClientId() {
     return `${getRootProjectPackageInfo().name}-${uuid.v4()}`;
+}
+
+export function loadCompressionPlugins() {
+    CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
+    CompressionCodecs[CompressionTypes.LZ4] = new (LZ4Codec as any)().codec;
 }


### PR DESCRIPTION
~According to the [KafkaJS docs](https://kafka.js.org/docs/producing#a-name-compression-a-compression) we wouldn't be able to support compression modes other than Gzip without taking on a new dependency.~

Edit: `cookie-cutter-kafka` already depends on the Snappy and LZ4 KafkaJS compression plugins, so those will be supported as part of this PR as well.