### PR TITLE
force application to restart on redis disconnect

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-redis",
-    "version": "1.4.0-beta.1",
+    "version": "1.4.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/redis/src/RedisProxy.ts
+++ b/packages/redis/src/RedisProxy.ts
@@ -75,6 +75,7 @@ export class RedisProxy implements IRequireInitialization, IDisposable {
         });
         this.client.on("end", () => {
             this.logger.debug("Disconnected from Redis");
+            throw new Error("connection to Redis lost");
         });
 
         this.asyncGet = promisify(this.client.get).bind(this.client);


### PR DESCRIPTION
Redis stream consumers frequently get stuck consuming the stream when the connection to Redis is lost. Even though the logs indicate the connection was re-established, no new messages are flowing in anymore. As a quick fix we are forcing the application to terminate on disconnect.

This closes #206 