### PR TITLE
upgrading gcp dependencies in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "examples/*"
   ],
   "resolutions": {
-    "lz4": "0.6.5",
+    "lz4": "0.6.3",
     "marked": "^0.7.0",
     "bl": "^4.0.3",
     "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "examples/*"
   ],
   "resolutions": {
-    "lz4": "0.6.3",
+    "lz4": "0.6.5",
     "marked": "^0.7.0",
     "bl": "^4.0.3",
     "node-fetch": "^2.6.1",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-gcp",
-    "version": "1.4.0-beta.1",
+    "version": "1.4.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -13,9 +13,9 @@
         "url": "https://github.com/walmartlabs/cookie-cutter/issues"
     },
     "dependencies": {
-        "@google-cloud/bigquery": "4.7.0",
-        "@google-cloud/pubsub": "2.0.0",
-        "@google-cloud/storage": "4.4.0"
+        "@google-cloud/bigquery": "5.5.0",
+        "@google-cloud/pubsub": "2.10.0",
+        "@google-cloud/storage": "5.8.0"
     },
     "peerDependencies": {
         "@walmartlabs/cookie-cutter-core": "^1.4.0-beta"


### PR DESCRIPTION
As part of the effort to fix ongoing issues with `task-response-uploader-gcp` service will try to see if upgrading the dependencies can help with some of said issues. 