### PR TITLE
Fixed issue with wrong grpcClient timing metric's unit

### DIFF
--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-grpc",
-    "version": "1.4.0-beta.0",
+    "version": "1.4.0-beta.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/grpc/src/internal/GrpcInputSource.ts
+++ b/packages/grpc/src/internal/GrpcInputSource.ts
@@ -186,7 +186,7 @@ export class GrpcInputSource implements IInputSource, IRequireInitialization {
                                 result: error ? GrpcMetricResult.Error : GrpcMetricResult.Success,
                             });
                             const currentPerformanceTime = performance.now();
-                            const runTime = Math.round(currentPerformanceTime - startTime);
+                            const runTime = (currentPerformanceTime - startTime) / 1000;
                             this.metrics.timing(GrpcMetrics.RequestProcessingTime, runTime, {
                                 path: method.path,
                                 peer: call.getPeer(),

--- a/packages/grpc/src/internal/client.ts
+++ b/packages/grpc/src/internal/client.ts
@@ -298,7 +298,7 @@ function emitTimerMetric(
     metrics: IMetrics
 ): void {
     const currentPerformanceTime = performance.now();
-    const runTime = Math.round((currentPerformanceTime - startTime)/1000);
+    const runTime = Math.round((currentPerformanceTime - startTime) / 1000);
     metrics.timing(GrpcMetrics.RequestProcessingTime, runTime, {
         path,
         endpoint,

--- a/packages/grpc/src/internal/client.ts
+++ b/packages/grpc/src/internal/client.ts
@@ -298,7 +298,7 @@ function emitTimerMetric(
     metrics: IMetrics
 ): void {
     const currentPerformanceTime = performance.now();
-    const runTime = Math.round((currentPerformanceTime - startTime) / 1000);
+    const runTime = (currentPerformanceTime - startTime) / 1000;
     metrics.timing(GrpcMetrics.RequestProcessingTime, runTime, {
         path,
         endpoint,

--- a/packages/grpc/src/internal/client.ts
+++ b/packages/grpc/src/internal/client.ts
@@ -298,7 +298,7 @@ function emitTimerMetric(
     metrics: IMetrics
 ): void {
     const currentPerformanceTime = performance.now();
-    const runTime = Math.round(currentPerformanceTime - startTime);
+    const runTime = Math.round((currentPerformanceTime - startTime)/1000);
     metrics.timing(GrpcMetrics.RequestProcessingTime, runTime, {
         path,
         endpoint,


### PR DESCRIPTION
This PR is attempting to fix issue #211 where the performance timing being passed in is in millisecs whereas the underlying metric collector expects the unit to be seconds.

I'm not sure if the fix is too restrictive in a sense that we might not be able to instrument in millisecs if we wanted to later on. Perhaps, a better fix is in the following `timing` function?

https://github.com/walmartlabs/cookie-cutter/blob/52aaa98ea418c2e8be923f574c5d19ae23fbd563/packages/prometheus/src/index.ts#L142


