### PR TITLE
Log out a detailed error message for inserting data into big query

### DIFF
--- a/packages/gcp/src/BigQueryClient.ts
+++ b/packages/gcp/src/BigQueryClient.ts
@@ -92,7 +92,7 @@ export class BigQueryClient implements IBigQueryClient, IRequireInitialization {
             if (e.errors) {
                 detailedErrorMsg = JSON.stringify(e.errors);
             }
-            this.logger.error("An failure occured while inserting data into big query", {errorMsg: detailedErrorMsg});
+            this.logger.error("An failure occured while inserting data into big query", { errorMsg: detailedErrorMsg, });
             throw e;
         } finally {
             span.finish();

--- a/packages/gcp/src/BigQueryClient.ts
+++ b/packages/gcp/src/BigQueryClient.ts
@@ -92,7 +92,9 @@ export class BigQueryClient implements IBigQueryClient, IRequireInitialization {
             if (e.errors) {
                 detailedErrorMsg = JSON.stringify(e.errors);
             }
-            this.logger.error("An failure occured while inserting data into big query", { errorMsg: detailedErrorMsg, });
+            this.logger.error("An failure occured while inserting data into big query", { 
+                errorMsg: detailedErrorMsg, 
+            });
             throw e;
         } finally {
             span.finish();


### PR DESCRIPTION
While inserting data into big query, it sends a response back if there's an error. This can be extremely helpful while debugging