### PR TITLE
Add missing Kafka and Prometheus exports

### DIFF
--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kafka",
-    "version": "1.4.0-beta.3",
+    "version": "1.4.0-beta.4",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/kafka/src/index.ts
+++ b/packages/kafka/src/index.ts
@@ -155,6 +155,8 @@ export enum KafkaMetadata {
     ConsumerGroupEpoch = "consumerGroupEpoch",
 }
 
+export { IRawKafkaMessage } from "./model";
+
 export interface IKafkaMessagePreprocessor {
     process(msg: IRawKafkaMessage): IRawKafkaMessage;
 }

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-prometheus",
-    "version": "1.4.0-beta.0",
+    "version": "1.4.0-beta.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/prometheus/src/index.ts
+++ b/packages/prometheus/src/index.ts
@@ -222,6 +222,8 @@ class PrometheusMetrics
     }
 }
 
+export { IPrometheusConfiguration } from "./config";
+
 export function prometheus(prometheusConfig: IPrometheusConfiguration): IMetrics {
     const defaults: IPrometheusConfiguration = {
         port: 3000,


### PR DESCRIPTION
`IPrometheusConfiguration` and `IRawKafkaMessage` should be part of the public API.