### PR TITLE
Redis Stream: Throw error in case of failed ack message

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-redis",
-    "version": "1.3.0-beta.12",
+    "version": "1.3.0-beta.13",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/redis/src/RedisStreamSource.ts
+++ b/packages/redis/src/RedisStreamSource.ts
@@ -65,11 +65,12 @@ export class RedisStreamSource implements IInputSource, IRequireInitialization, 
                     this.config.blockTimeout
                 );
 
+                this.metrics.gauge(RedisMetrics.IncomingBatchSize, messages.length, {});
+
                 if (messages.length === 0) {
                     break;
                 }
 
-                this.metrics.gauge(RedisMetrics.IncomingBatchSize, messages.length, {});
                 for (const message of messages) {
                     // when calling XReadGroup again only get messages after this one
                     streams.filter((s) => s.name === message.streamName)[0].id = message.messageId;
@@ -242,6 +243,7 @@ export class RedisStreamSource implements IInputSource, IRequireInitialization, 
 
             if (!err) {
                 this.logger.error("failed to ack message", err, { messageId, stream, consumerId });
+                throw e;
             }
         } finally {
             span.finish();


### PR DESCRIPTION
We use XREADGROUP for redis stream and that has a know side effect where sometimes server is yet not sure if a message was processed at least once and in that case already processed messaged are picked up and since those do not exist in PEL, ack would fail. In our case we are seeing that when this happens then instead of just skipping the failed ack message cc app gets stuck and we eventually loose consumer group. This change is to throw an error in case ack fails so app does not get stuck.