### PR TITLE
Add logs to composite input source to debug lost sources

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.5.0-beta.0",
+    "version": "1.5.0-beta.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/internal/helpers.test.ts
+++ b/packages/core/src/__test__/internal/helpers.test.ts
@@ -5,6 +5,7 @@ This source code is licensed under the Apache 2.0 license found in the
 LICENSE file in the root directory of this source tree.
 */
 
+import { DefaultComponentContext } from "../..";
 import { roundRobinIterators } from "../../../src/internal/helpers";
 
 async function* iterator<T>(items: T[]): AsyncIterableIterator<T> {
@@ -21,7 +22,7 @@ describe("roundRobinIterators", () => {
         const it2 = iterator(values2);
 
         const all = [];
-        for await (const n of roundRobinIterators([it1, it2])) {
+        for await (const n of roundRobinIterators([it1, it2], DefaultComponentContext.logger)) {
             all.push(n);
         }
 

--- a/packages/core/src/internal/CompositeInputSource.ts
+++ b/packages/core/src/internal/CompositeInputSource.ts
@@ -56,7 +56,7 @@ export class CompositeInputSource
 
         let source = sources[0];
         if (sources.length > 1) {
-            source = roundRobinIterators(sources);
+            source = roundRobinIterators(sources, this.logger);
         }
 
         let sequence = 0;

--- a/packages/core/src/internal/helpers.ts
+++ b/packages/core/src/internal/helpers.ts
@@ -10,7 +10,7 @@ import { BoundedPriorityQueue } from "../utils";
 
 export async function* roundRobinIterators<T>(
     inputs: AsyncIterableIterator<T>[],
-    logger: ILogger,
+    logger: ILogger
 ): AsyncIterableIterator<T> {
     const pipe = new BoundedPriorityQueue<T>(1);
 
@@ -39,7 +39,6 @@ export async function* roundRobinIterators<T>(
 }
 
 export function dumpOpenHandles(logger: ILogger): void {
-
     const wtf = require("wtfnode");
     const util = require("util");
     wtf.setLogger("info", (...args: any[]) => {

--- a/packages/core/src/internal/helpers.ts
+++ b/packages/core/src/internal/helpers.ts
@@ -9,7 +9,8 @@ import { ILogger } from "..";
 import { BoundedPriorityQueue } from "../utils";
 
 export async function* roundRobinIterators<T>(
-    inputs: AsyncIterableIterator<T>[]
+    inputs: AsyncIterableIterator<T>[],
+    logger: ILogger,
 ): AsyncIterableIterator<T> {
     const pipe = new BoundedPriorityQueue<T>(1);
 
@@ -25,6 +26,7 @@ export async function* roundRobinIterators<T>(
                 }
             } catch (e) {
                 // ignore, close pipe
+                logger.warn("Error iterating input source", { msg: e });
             } finally {
                 if (++done === inputs.length) {
                     pipe.close();
@@ -37,6 +39,7 @@ export async function* roundRobinIterators<T>(
 }
 
 export function dumpOpenHandles(logger: ILogger): void {
+
     const wtf = require("wtfnode");
     const util = require("util");
     wtf.setLogger("info", (...args: any[]) => {


### PR DESCRIPTION
We have seen an issue where in case of an error being thrown for a cc app with composite input source that error is ignored and we keep running the app without the input source with issue which is not what we always want to do. We only got to know about this issue after we attached a remote debugger to our app in production. This change is to get some logs to easily identify and eventually remediate this issue with composite input source.