### PR TITLE
Reduce cardinality GRPC peer remove from metrics

### DIFF
--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-grpc",
-    "version": "1.5.0-beta.1",
+    "version": "1.5.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/grpc/src/internal/GrpcInputSource.ts
+++ b/packages/grpc/src/internal/GrpcInputSource.ts
@@ -137,7 +137,6 @@ export class GrpcInputSource implements IInputSource, IRequireInitialization {
 
                     this.metrics.increment(GrpcMetrics.RequestReceived, {
                         path: method.path,
-                        peer: call.getPeer(),
                     });
                     const metadata = call.metadata.getMap();
                     const spanContext = this.tracer.extract(FORMAT_HTTP_HEADERS, metadata);
@@ -182,7 +181,6 @@ export class GrpcInputSource implements IInputSource, IRequireInitialization {
                             }
                             this.metrics.increment(GrpcMetrics.RequestProcessed, {
                                 path: method.path,
-                                peer: call.getPeer(),
                                 result: error ? GrpcMetricResult.Error : GrpcMetricResult.Success,
                             });
                             const currentPerformanceTime = performance.now();

--- a/packages/grpc/src/internal/GrpcInputSource.ts
+++ b/packages/grpc/src/internal/GrpcInputSource.ts
@@ -189,7 +189,6 @@ export class GrpcInputSource implements IInputSource, IRequireInitialization {
                             const runTime = (currentPerformanceTime - startTime) / 1000;
                             this.metrics.timing(GrpcMetrics.RequestProcessingTime, runTime, {
                                 path: method.path,
-                                peer: call.getPeer(),
                             });
                         }
                     );


### PR DESCRIPTION
Peer is creating a bunch of cardinality aspects in metrics.  More of a logging thing rather then a metrics.