### PR TITLE
Added ability to pull custom message headers into message metadata for kafka

### DIFF
--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-kafka",
-    "version": "1.5.0-beta.1",
+    "version": "1.5.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/kafka/src/KafkaSource.ts
+++ b/packages/kafka/src/KafkaSource.ts
@@ -142,7 +142,7 @@ export class KafkaSource implements IInputSource, IRequireInitialization, IDispo
                 }
                 if (this.config.additionalHeaderNames) {
                     const headerKeys: string[] = Object.keys(this.config.additionalHeaderNames);
-                    for (let headerKey of headerKeys) {
+                    for (const headerKey of headerKeys) {
                         if (
                             headers[this.config.additionalHeaderNames[headerKey]] &&
                             !fromHeaders[headerKey]

--- a/packages/kafka/src/KafkaSource.ts
+++ b/packages/kafka/src/KafkaSource.ts
@@ -140,6 +140,19 @@ export class KafkaSource implements IInputSource, IRequireInitialization, IDispo
                         fromHeaders[EventSourcedMetadata.Timestamp] = new Date(dt);
                     }
                 }
+                if (this.config.additionalHeaderNames) {
+                    const headerKeys: string[] = Object.keys(this.config.additionalHeaderNames);
+                    for (let headerKey of headerKeys) {
+                        if (
+                            headers[this.config.additionalHeaderNames[headerKey]] &&
+                            !fromHeaders[headerKey]
+                        ) {
+                            fromHeaders[headerKey] = headers[
+                                this.config.additionalHeaderNames[headerKey]
+                            ].toString();
+                        }
+                    }
+                }
                 const metadata: IKafkaMessageMetadata = {
                     ...fromHeaders,
                     [KafkaMetadata.Topic]: message.topic,

--- a/packages/kafka/src/__test__/KafkaSource.test.ts
+++ b/packages/kafka/src/__test__/KafkaSource.test.ts
@@ -59,6 +59,7 @@ describe("KafkaSource", () => {
                     "X-Message-Type": "application/json",
                     rawHeader: "raw header value",
                     externalHeader: "external header value",
+                    ignoredHeader: "this header is ignored",
                 },
                 timestamp: "1554845507549",
                 value: Buffer.from(encoder.encode({ type: "test", payload: { foo: "bar" } })),
@@ -110,6 +111,7 @@ describe("KafkaSource", () => {
                     rawMessage.headers[rawHeaderName]
                 );
             }
+            expect(received.metadata("ignoredHeader")).toBeUndefined();
         });
 
         it("should attempt to add offsets for non-transactional messages when releasing", async () => {

--- a/packages/kafka/src/__test__/KafkaSource.test.ts
+++ b/packages/kafka/src/__test__/KafkaSource.test.ts
@@ -32,6 +32,10 @@ describe("KafkaSource", () => {
     const topicName = "topic";
     const consumerGroupId = "consumer-group";
     const broker = "broker:9092";
+    const additionalHeaderName1 = "additional-header-1";
+    const additionalHeaderName2 = "additional-header-2";
+    const additionalHeaderValue1 = "custom header value 1";
+    const additionalHeaderValue2 = "custom header value 2";
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -52,8 +56,8 @@ describe("KafkaSource", () => {
                 key: Buffer.from("key"),
                 headers: {
                     "X-Message-Type": "application/json",
-                    "additional_header_1": "custom header 1",
-                    "additional_header_2": "custom header 2",
+                    [additionalHeaderName1]: additionalHeaderValue1,
+                    [additionalHeaderName2]: additionalHeaderValue2,
                 },
                 timestamp: "1554845507549",
                 value: Buffer.from(encoder.encode({ type: "test", payload: { foo: "bar" } })),
@@ -75,8 +79,8 @@ describe("KafkaSource", () => {
                 eos: true,
                 headerNames: DefaultKafkaHeaderNames,
                 additionalHeaderNames: {
-                    "add1": "additional_header_1",
-                    "add2": "additional_header_2",
+                    header1: additionalHeaderName1,
+                    header2: additionalHeaderName2,
                 },
                 preprocessor: {
                     process: (msg) => msg,
@@ -101,8 +105,8 @@ describe("KafkaSource", () => {
                 expect(received.metadata(KafkaMetadata.Topic)).toEqual(topicName);
             expect(received.metadata(KafkaMetadata.ExactlyOnceSemantics)).toEqual(true);
             expect(received.metadata(KafkaMetadata.ConsumerGroupId)).toEqual(consumerGroupId);
-            expect(received.metadata("add1")).toEqual(rawMessage.headers["additional_header_1"]);
-            expect(received.metadata("add2")).toEqual(rawMessage.headers["additional_header_2"]);
+            expect(received.metadata("header1")).toEqual(additionalHeaderValue1);
+            expect(received.metadata("header2")).toEqual(additionalHeaderValue2);
         });
 
         it("should attempt to add offsets for non-transactional messages when releasing", async () => {

--- a/packages/kafka/src/__test__/config.test.ts
+++ b/packages/kafka/src/__test__/config.test.ts
@@ -71,4 +71,18 @@ describe("KafkaSubscriptionConfiguration", () => {
             { name: "topic3", offsetResetStrategy: KafkaOffsetResetStrategy.Earliest },
         ]);
     });
+
+    it("has correct additional headers in the config", async() => {
+        const actual = config.parse(KafkaSubscriptionConfiguration, {
+            additionalHeaderNames: {
+                add1: "additional_1",
+                add2: "additional_2",
+            },
+        });
+
+        expect(actual.additionalHeaderNames).toMatchObject({
+            add1: "additional_1",
+            add2: "additional_2",
+        });
+    });
 });

--- a/packages/kafka/src/__test__/config.test.ts
+++ b/packages/kafka/src/__test__/config.test.ts
@@ -75,14 +75,14 @@ describe("KafkaSubscriptionConfiguration", () => {
     it("has correct additional headers in the config", async () => {
         const actual = config.parse(KafkaSubscriptionConfiguration, {
             additionalHeaderNames: {
-                add1: "additional_1",
-                add2: "additional_2",
+                internal_header_one: "raw_message_header_one",
+                internal_header_two: "raw_message_header_two",
             },
         });
 
         expect(actual.additionalHeaderNames).toMatchObject({
-            add1: "additional_1",
-            add2: "additional_2",
+            internal_header_one: "raw_message_header_one",
+            internal_header_two: "raw_message_header_two",
         });
     });
 });

--- a/packages/kafka/src/__test__/config.test.ts
+++ b/packages/kafka/src/__test__/config.test.ts
@@ -72,7 +72,7 @@ describe("KafkaSubscriptionConfiguration", () => {
         ]);
     });
 
-    it("has correct additional headers in the config", async() => {
+    it("has correct additional headers in the config", async () => {
         const actual = config.parse(KafkaSubscriptionConfiguration, {
             additionalHeaderNames: {
                 add1: "additional_1",

--- a/packages/kafka/src/config.ts
+++ b/packages/kafka/src/config.ts
@@ -149,6 +149,14 @@ export class KafkaSubscriptionConfiguration extends KafkaBrokerConfiguration
     public get sessionTimeout(): number {
         return config.noop();
     }
+
+    @config.field(config.converters.none)
+    public set additionalHeaderNames(_: { [key: string ]: string }) {
+        config.noop();
+    }
+    public get additionalHeaderNames(): { [key: string ]: string } {
+        return config.noop();
+    }
 }
 
 @config.section

--- a/packages/kafka/src/config.ts
+++ b/packages/kafka/src/config.ts
@@ -151,10 +151,10 @@ export class KafkaSubscriptionConfiguration extends KafkaBrokerConfiguration
     }
 
     @config.field(config.converters.none)
-    public set additionalHeaderNames(_: { [key: string ]: string }) {
+    public set additionalHeaderNames(_: { [key: string]: string }) {
         config.noop();
     }
-    public get additionalHeaderNames(): { [key: string ]: string } {
+    public get additionalHeaderNames(): { [key: string]: string } {
         return config.noop();
     }
 }

--- a/packages/kafka/src/index.ts
+++ b/packages/kafka/src/index.ts
@@ -89,6 +89,13 @@ export interface IKafkaSubscriptionConfiguration {
      * Defaults to 30s, src: https://kafka.js.org/docs/consuming
      */
     readonly sessionTimeout?: number;
+
+    /**
+     * Additional header names.
+     * Useful when consuming messages that have additional information in the message header that
+     * needs to be available in message metadata.
+     */
+    readonly additionalHeaderNames?: { [key: string]: string }
 }
 
 export interface IKafkaClientConfiguration {

--- a/packages/kafka/src/index.ts
+++ b/packages/kafka/src/index.ts
@@ -95,7 +95,7 @@ export interface IKafkaSubscriptionConfiguration {
      * Useful when consuming messages that have additional information in the message header that
      * needs to be available in message metadata.
      */
-    readonly additionalHeaderNames?: { [key: string]: string }
+    readonly additionalHeaderNames?: { [key: string]: string };
 }
 
 export interface IKafkaClientConfiguration {


### PR DESCRIPTION
Sometimes messages that were produced by another system have additional information as part of the message headers.  There is a need to propagate that information as part of message metadata.  This PR allows users to specify additional header names that could be added to message metadata.