### PR TITLE
Add cc health check to prevent stuck apps for any input sources

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-core",
-    "version": "1.6.0-beta.0",
+    "version": "1.6.0-beta.1",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -690,7 +690,6 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 .published(new CapturingOutputSink(capture))
                 .done()
                 .run(runtime);
-            await Promise.race([sleep(1000), app]);
             app.cancel();
             expect(capture.length).toBe(2);
         });
@@ -733,7 +732,6 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
-                await Promise.race([sleep(1000), app]);
                 expect(capture.length).toBe(2);
             } catch (err) {
                 error = err;
@@ -783,7 +781,6 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
-                await Promise.race([sleep(1000), app]);
             } catch (err) {
                 error = err;
             } finally {

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -31,6 +31,7 @@ import {
     MessageProcessingResults,
     MessageRef,
     OutputSinkConsistencyLevel,
+    QueueFullHandlingMode,
     SequenceConflictError,
     StateRef,
 } from "../model";
@@ -652,6 +653,131 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
 
             const published = capture.map((m) => m.message);
             expect(published).toMatchObject([inc(1), inc(2)]);
+        });
+
+        it("successfully validates input queue with length within capacity", async () => {
+            const runtime: IApplicationRuntimeBehavior = {
+                dispatch: { mode: ErrorHandlingMode.LogAndFail },
+                sink: { mode: ErrorHandlingMode.LogAndFail },
+                parallelism: {
+                  mode: ParallelismMode.Concurrent,
+                  concurrencyConfiguration: {
+                    inputQueueCapacity: 10,
+                    outputQueueCapacity: 10,
+                    inputQueueValidationConfig: {
+                        timeOutInMs: 1,
+                        validationIntervalInMs: 0.5,
+                        mode: QueueFullHandlingMode.LogAndFail,
+                    }
+                  },
+                },
+            };
+
+            const capture = new Array();
+            await Application.create()
+                .input()
+                .add(new StaticInputSource([inc(4), inc(8)]))
+                .done()
+                .logger(console)
+                .dispatch({
+                    onIncrement: async (msg: Increment, ctx: IDispatchContext) => {
+                        await sleep(10);
+                        ctx.publish(Increment, msg);
+                    },
+                })
+                .output()
+                .published(new CapturingOutputSink(capture))
+                .done()
+                .run(runtime);
+            
+            expect(capture.length).toBe(2);
+        });
+        
+        it("does not throw error if input queue length breaches capacity in LogAndContinue mode", async () => {
+            const runtime: IApplicationRuntimeBehavior = {
+                dispatch: { mode: ErrorHandlingMode.LogAndContinue },
+                sink: { mode: ErrorHandlingMode.LogAndContinue },
+                parallelism: {
+                  mode: ParallelismMode.Concurrent,
+                  concurrencyConfiguration: {
+                    inputQueueCapacity: 1,
+                    outputQueueCapacity: 1,
+                    inputQueueValidationConfig: {
+                        timeOutInMs: 1,
+                        validationIntervalInMs: 0.5,
+                        mode: QueueFullHandlingMode.LogAndContinue,
+                    }
+                  },
+                },
+            };
+
+            const capture = new Array();
+            let error;
+            try {
+                await Application.create()
+                    .input()
+                    .add(new StaticInputSource([inc(4), inc(8)]))
+                    .done()
+                    .logger(console)
+                    .dispatch({
+                        onIncrement: async (msg: Increment, ctx: IDispatchContext) => {
+                            await sleep(10);
+                            ctx.publish(Increment, msg);
+                        },
+                    })
+                    .output()
+                    .published(new CapturingOutputSink(capture))
+                    .done()
+                    .run(runtime);
+                
+                expect(capture.length).toBe(2);
+            } catch(err) {
+                error = err;
+            }
+            expect(error).not.toBeDefined();
+        });
+
+        it("throws an error if input queue length breaches capacity in LogAndFail mode", async () => {
+            const runtime: IApplicationRuntimeBehavior = {
+                dispatch: { mode: ErrorHandlingMode.LogAndFail },
+                sink: { mode: ErrorHandlingMode.LogAndFail },
+                parallelism: {
+                  mode: ParallelismMode.Concurrent,
+                  concurrencyConfiguration: {
+                    inputQueueCapacity: 1,
+                    outputQueueCapacity: 1,
+                    inputQueueValidationConfig: {
+                        timeOutInMs: 1,
+                        validationIntervalInMs: 0.5,
+                        mode: QueueFullHandlingMode.LogAndFail,
+                    }
+                  },
+                },
+            };
+
+            const capture = new Array();
+            let error;
+            try {
+                await Application.create()
+                    .input()
+                    .add(new StaticInputSource([inc(4), inc(8), inc(12)]))
+                    .done()
+                    .logger(console)
+                    .dispatch({
+                        onIncrement: async (msg: Increment, ctx: IDispatchContext) => {
+                            await sleep(10);
+                            ctx.publish(Increment, msg);
+                        },
+                    })
+                    .output()
+                    .published(new CapturingOutputSink(capture))
+                    .done()
+                    .run(runtime);       
+                await sleep(1000);         
+            } catch(err) {
+                error = err;
+            }
+            expect(error).toBeDefined();
         });
     });
 }

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -39,7 +39,7 @@ import { Future } from "../utils";
 import { dec, Decrement, inc, Increment, TallyAggregator, TallyState } from "./tally";
 import { runStatefulApp, runStatelessApp, runMaterializedStatefulApp } from "./util";
 
-jest.setTimeout(30000);
+jest.setTimeout(120000);
 
 afterAll((done) => {
     done();
@@ -183,7 +183,7 @@ for (const mode of [ParallelismMode.Serial, ParallelismMode.Concurrent, Parallel
             try {
                 await Application.create()
                     .input()
-                    .add(new StaticInputSource([{ type: "Test", payload: {}}]))
+                    .add(new StaticInputSource([{ type: "Test", payload: {} }]))
                     .done()
                     .dispatch({
                         onTest: async (_: any, ctx: IDispatchContext<TallyState>) => {
@@ -722,9 +722,8 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
             };
             const capture = new Array();
             let error;
-            let app;
             try {
-                app = await Application.create()
+                await Application.create()
                     .input()
                     .add(new StaticInputSource([inc(4), inc(8)]))
                     .done()
@@ -741,10 +740,6 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 expect(capture.length).toBe(2);
             } catch (err) {
                 error = err;
-            } finally {
-                if (app) {
-                    app.cancel();
-                }
             }
             expect(error).not.toBeDefined();
         });
@@ -771,9 +766,8 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
 
             const capture = new Array();
             let error;
-            let app;
             try {
-                app = await Application.create()
+                await Application.create()
                     .input()
                     .add(new StaticInputSource([inc(4), inc(8), inc(12)]))
                     .done()
@@ -788,12 +782,8 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
-                app.reject();
-                // await Promise.race([sleep(1000), app]);
             } catch (err) {
                 error = err;
-            } finally {
-                app?.cancel();
             }
             expect(error).toBeDefined();
         });

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -655,7 +655,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
             expect(published).toMatchObject([inc(1), inc(2)]);
         });
 
-        it("successfully validates input queue with length within capacity", async () => {
+        xit("successfully validates input queue with length within capacity", async () => {
             const runtime: IApplicationRuntimeBehavior = {
                 dispatch: { mode: ErrorHandlingMode.LogAndFail },
                 sink: { mode: ErrorHandlingMode.LogAndFail },
@@ -694,7 +694,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
             expect(capture.length).toBe(2);
         });
 
-        it("does not throw error if input queue length breaches capacity in LogAndContinue mode", async () => {
+        xit("does not throw error if input queue length breaches capacity in LogAndContinue mode", async () => {
             const runtime: IApplicationRuntimeBehavior = {
                 dispatch: { mode: ErrorHandlingMode.LogAndContinue },
                 sink: { mode: ErrorHandlingMode.LogAndContinue },
@@ -739,7 +739,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
             expect(error).not.toBeDefined();
         });
 
-        it("throws an error if input queue length breaches capacity in LogAndFail mode", async () => {
+        xit("throws an error if input queue length breaches capacity in LogAndFail mode", async () => {
             const runtime: IApplicationRuntimeBehavior = {
                 dispatch: { mode: ErrorHandlingMode.LogAndFail },
                 sink: { mode: ErrorHandlingMode.LogAndFail },

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -41,6 +41,10 @@ import { runStatefulApp, runStatelessApp, runMaterializedStatefulApp } from "./u
 
 jest.setTimeout(20000);
 
+afterAll( done => {
+    done();
+})
+
 for (const mode of [ParallelismMode.Serial, ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
     describe(`Application in ${ParallelismMode[mode]} mode`, () => {
         it("routes all published messages to output sink", async () => {

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -664,11 +664,13 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                   concurrencyConfiguration: {
                     inputQueueCapacity: 10,
                     outputQueueCapacity: 10,
-                    inputQueueValidationConfig: {
-                        timeOutInMs: 1,
-                        validationIntervalInMs: 0.5,
-                        mode: QueueFullHandlingMode.LogAndFail,
-                    }
+                    healthCheck: {
+                        inputQueueValidation: {
+                            timeOutInMs: 1,
+                            validationIntervalInMs: 0.5,
+                            mode: QueueFullHandlingMode.LogAndFail,
+                        },
+                    },
                   },
                 },
             };
@@ -702,11 +704,13 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                   concurrencyConfiguration: {
                     inputQueueCapacity: 1,
                     outputQueueCapacity: 1,
-                    inputQueueValidationConfig: {
-                        timeOutInMs: 1,
-                        validationIntervalInMs: 0.5,
-                        mode: QueueFullHandlingMode.LogAndContinue,
-                    }
+                    healthCheck: {
+                        inputQueueValidation: {
+                            timeOutInMs: 1,
+                            validationIntervalInMs: 0.5,
+                            mode: QueueFullHandlingMode.LogAndContinue,
+                        },
+                    },
                   },
                 },
             };
@@ -746,11 +750,13 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                   concurrencyConfiguration: {
                     inputQueueCapacity: 1,
                     outputQueueCapacity: 1,
-                    inputQueueValidationConfig: {
-                        timeOutInMs: 1,
-                        validationIntervalInMs: 0.5,
-                        mode: QueueFullHandlingMode.LogAndFail,
-                    }
+                    healthCheck: {
+                        inputQueueValidation: {
+                            timeOutInMs: 1,
+                            validationIntervalInMs: 0.5,
+                            mode: QueueFullHandlingMode.LogAndFail,
+                        },
+                    },
                   },
                 },
             };

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -680,7 +680,6 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 .input()
                 .add(new StaticInputSource([inc(4), inc(8)]))
                 .done()
-                .logger(console)
                 .dispatch({
                     onIncrement: async (msg: Increment, ctx: IDispatchContext) => {
                         await sleep(10);
@@ -718,11 +717,10 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
             const capture = new Array();
             let error;
             try {
-                await Application.create()
+                const app = Application.create()
                     .input()
                     .add(new StaticInputSource([inc(4), inc(8)]))
                     .done()
-                    .logger(console)
                     .dispatch({
                         onIncrement: async (msg: Increment, ctx: IDispatchContext) => {
                             await sleep(10);
@@ -733,7 +731,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
-
+                await Promise.race([sleep(5000), app]);
                 expect(capture.length).toBe(2);
             } catch (err) {
                 error = err;
@@ -764,11 +762,10 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
             const capture = new Array();
             let error;
             try {
-                await Application.create()
+                const app = Application.create()
                     .input()
                     .add(new StaticInputSource([inc(4), inc(8), inc(12)]))
                     .done()
-                    .logger(console)
                     .dispatch({
                         onIncrement: async (msg: Increment, ctx: IDispatchContext) => {
                             await sleep(10);
@@ -779,7 +776,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
-                await sleep(1000);
+                await Promise.race([sleep(5000), app]);
             } catch (err) {
                 error = err;
             }

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -690,6 +690,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 .published(new CapturingOutputSink(capture))
                 .done()
                 .run(runtime);
+            await Promise.race([sleep(100), app]);
             app.cancel();
             expect(capture.length).toBe(2);
         });
@@ -732,6 +733,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
+                await Promise.race([sleep(1000), app]);
                 expect(capture.length).toBe(2);
             } catch (err) {
                 error = err;
@@ -781,6 +783,7 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
+                await Promise.race([sleep(1000), app]);
             } catch (err) {
                 error = err;
             } finally {

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -41,9 +41,9 @@ import { runStatefulApp, runStatelessApp, runMaterializedStatefulApp } from "./u
 
 jest.setTimeout(20000);
 
-afterAll( done => {
+afterAll((done) => {
     done();
-})
+});
 
 for (const mode of [ParallelismMode.Serial, ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
     describe(`Application in ${ParallelismMode[mode]} mode`, () => {

--- a/packages/core/src/__test__/Application.test.ts
+++ b/packages/core/src/__test__/Application.test.ts
@@ -660,18 +660,18 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 dispatch: { mode: ErrorHandlingMode.LogAndFail },
                 sink: { mode: ErrorHandlingMode.LogAndFail },
                 parallelism: {
-                  mode: ParallelismMode.Concurrent,
-                  concurrencyConfiguration: {
-                    inputQueueCapacity: 10,
-                    outputQueueCapacity: 10,
-                    healthCheck: {
-                        inputQueueValidation: {
-                            timeOutInMs: 1,
-                            validationIntervalInMs: 0.5,
-                            mode: QueueFullHandlingMode.LogAndFail,
+                    mode: ParallelismMode.Concurrent,
+                    concurrencyConfiguration: {
+                        inputQueueCapacity: 10,
+                        outputQueueCapacity: 10,
+                        healthCheck: {
+                            inputQueueValidation: {
+                                timeOutInMs: 1,
+                                validationIntervalInMs: 0.5,
+                                mode: QueueFullHandlingMode.LogAndFail,
+                            },
                         },
                     },
-                  },
                 },
             };
 
@@ -691,27 +691,27 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 .published(new CapturingOutputSink(capture))
                 .done()
                 .run(runtime);
-            
+
             expect(capture.length).toBe(2);
         });
-        
+
         it("does not throw error if input queue length breaches capacity in LogAndContinue mode", async () => {
             const runtime: IApplicationRuntimeBehavior = {
                 dispatch: { mode: ErrorHandlingMode.LogAndContinue },
                 sink: { mode: ErrorHandlingMode.LogAndContinue },
                 parallelism: {
-                  mode: ParallelismMode.Concurrent,
-                  concurrencyConfiguration: {
-                    inputQueueCapacity: 1,
-                    outputQueueCapacity: 1,
-                    healthCheck: {
-                        inputQueueValidation: {
-                            timeOutInMs: 1,
-                            validationIntervalInMs: 0.5,
-                            mode: QueueFullHandlingMode.LogAndContinue,
+                    mode: ParallelismMode.Concurrent,
+                    concurrencyConfiguration: {
+                        inputQueueCapacity: 1,
+                        outputQueueCapacity: 1,
+                        healthCheck: {
+                            inputQueueValidation: {
+                                timeOutInMs: 1,
+                                validationIntervalInMs: 0.5,
+                                mode: QueueFullHandlingMode.LogAndContinue,
+                            },
                         },
                     },
-                  },
                 },
             };
 
@@ -733,9 +733,9 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .published(new CapturingOutputSink(capture))
                     .done()
                     .run(runtime);
-                
+
                 expect(capture.length).toBe(2);
-            } catch(err) {
+            } catch (err) {
                 error = err;
             }
             expect(error).not.toBeDefined();
@@ -746,18 +746,18 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                 dispatch: { mode: ErrorHandlingMode.LogAndFail },
                 sink: { mode: ErrorHandlingMode.LogAndFail },
                 parallelism: {
-                  mode: ParallelismMode.Concurrent,
-                  concurrencyConfiguration: {
-                    inputQueueCapacity: 1,
-                    outputQueueCapacity: 1,
-                    healthCheck: {
-                        inputQueueValidation: {
-                            timeOutInMs: 1,
-                            validationIntervalInMs: 0.5,
-                            mode: QueueFullHandlingMode.LogAndFail,
+                    mode: ParallelismMode.Concurrent,
+                    concurrencyConfiguration: {
+                        inputQueueCapacity: 1,
+                        outputQueueCapacity: 1,
+                        healthCheck: {
+                            inputQueueValidation: {
+                                timeOutInMs: 1,
+                                validationIntervalInMs: 0.5,
+                                mode: QueueFullHandlingMode.LogAndFail,
+                            },
                         },
                     },
-                  },
                 },
             };
 
@@ -778,9 +778,9 @@ for (const mode of [ParallelismMode.Concurrent, ParallelismMode.Rpc]) {
                     .output()
                     .published(new CapturingOutputSink(capture))
                     .done()
-                    .run(runtime);       
-                await sleep(1000);         
-            } catch(err) {
+                    .run(runtime);
+                await sleep(1000);
+            } catch (err) {
                 error = err;
             }
             expect(error).toBeDefined();

--- a/packages/core/src/internal/ApplicationBuilder.ts
+++ b/packages/core/src/internal/ApplicationBuilder.ts
@@ -70,6 +70,7 @@ export class ApplicationBuilder implements IApplicationBuilder {
     private activeLogger: ILogger;
     private stateProvider: IStateProvider<any>;
     private messageTypeMapper: IMessageTypeMapper;
+    private processor?: IMessageProcessor;
 
     constructor() {
         this.inputBuilder = new InputBuilder(this);
@@ -100,6 +101,13 @@ export class ApplicationBuilder implements IApplicationBuilder {
         };
 
         return promise;
+    }
+
+    public inputQueueLength(): number {
+        if (this.processor) {
+            return this.processor.getInputQueueLength();
+        }
+        return 0;
     }
 
     private async internalRun(
@@ -231,7 +239,7 @@ export class ApplicationBuilder implements IApplicationBuilder {
             this.activeLogger.error("failed to initialize component", e);
         }
 
-        const processor = processorFunc({
+        this.processor = processorFunc({
             dispatcher: this.dispatcher,
             logger: this.activeLogger,
             messageTypeMapper: this.messageTypeMapper,
@@ -242,7 +250,7 @@ export class ApplicationBuilder implements IApplicationBuilder {
         });
 
         try {
-            await processor.initialize({
+            await this.processor.initialize({
                 metrics,
                 logger: this.activeLogger,
                 tracer,
@@ -280,7 +288,7 @@ export class ApplicationBuilder implements IApplicationBuilder {
                     }
                 });
             });
-            const done = processor.run(
+            const done = this.processor.run(
                 source,
                 source,
                 sink,

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -71,7 +71,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
         this.metrics.gauge(MessageProcessingMetrics.OutputQueue, this.outputQueue.length);
     }
 
-    private validateInputQueue() {
+    private healthCheck() {
         return new Promise((resolve, reject) => {
             this.queueValidationTimer = setInterval(() => {
                 if (this.inputQueue.isClosed()) {
@@ -119,7 +119,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
 
             let processes = [];
             if (this.config.inputQueueValidationConfig) {
-                processes.push(this.validateInputQueue());
+                processes.push(this.healthCheck());
             }
 
             processes.push(...[

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -96,6 +96,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                     }
                 }
             }, this.config.healthCheck.inputQueueValidation.validationIntervalInMs);
+            this.queueValidationTimer.unref();
         });
     }
 

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -79,9 +79,9 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                 }
                 if (this.inputQueue?.length >= this.config.inputQueueCapacity) {
                     const currentTimestamp = new Date().getTime();
-                    if(currentTimestamp - this.lastHandledMessageTimestamp >= this.config.inputQueueValidationConfig.timeOutInMs) {
+                    if(currentTimestamp - this.lastHandledMessageTimestamp >= this.config.healthCheck.inputQueueValidation.timeOutInMs) {
                         const msg = `Input queue has reached it's capacity, currentLength: ${this.inputQueue.length}, capacity: ${this.config.inputQueueCapacity}`;
-                        switch(this.config.inputQueueValidationConfig.mode) {
+                        switch(this.config.healthCheck.inputQueueValidation.mode) {
                             case QueueFullHandlingMode.LogAndFail:
                                 reject(new Error(msg));
                                 break;
@@ -93,7 +93,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                     }
                 }
             },
-            this.config.inputQueueValidationConfig.validationIntervalInMs);
+            this.config.healthCheck.inputQueueValidation.validationIntervalInMs);
             this.queueValidationTimer.unref();
         });
     }
@@ -118,7 +118,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
             }
 
             let processes = [];
-            if (this.config.inputQueueValidationConfig) {
+            if (this.config.healthCheck) {
                 processes.push(this.healthCheck());
             }
 

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -79,9 +79,12 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                 }
                 if (this.inputQueue?.length >= this.config.inputQueueCapacity) {
                     const currentTimestamp = new Date().getTime();
-                    if(currentTimestamp - this.lastDispatchedMessageTimestamp >= this.config.healthCheck.inputQueueValidation.timeOutInMs) {
+                    if (
+                        currentTimestamp - this.lastDispatchedMessageTimestamp >=
+                        this.config.healthCheck.inputQueueValidation.timeOutInMs
+                    ) {
                         const msg = `Input queue has reached it's capacity, currentLength: ${this.inputQueue.length}, capacity: ${this.config.inputQueueCapacity}`;
-                        switch(this.config.healthCheck.inputQueueValidation.mode) {
+                        switch (this.config.healthCheck.inputQueueValidation.mode) {
                             case QueueFullHandlingMode.LogAndFail:
                                 reject(new Error(msg));
                                 break;
@@ -92,8 +95,7 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                         }
                     }
                 }
-            },
-            this.config.healthCheck.inputQueueValidation.validationIntervalInMs);
+            }, this.config.healthCheck.inputQueueValidation.validationIntervalInMs);
             this.queueValidationTimer.unref();
         });
     }
@@ -117,21 +119,23 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                 timer.unref();
             }
 
-            let processes = [];
+            const processes = [];
             if (this.config.healthCheck) {
                 processes.push(this.healthCheck());
             }
 
-            processes.push(...[
-                this.inputLoop(source),
-                this.processingLoop(
-                    outputMessageEnricher,
-                    inputMessageMetricAnnotator,
-                    serviceDiscovery,
-                    dispatchRetrier
-                ),
-                this.outputLoop(sink, inputMessageMetricAnnotator, sinkRetrier),
-            ]);
+            processes.push(
+                ...[
+                    this.inputLoop(source),
+                    this.processingLoop(
+                        outputMessageEnricher,
+                        inputMessageMetricAnnotator,
+                        serviceDiscovery,
+                        dispatchRetrier
+                    ),
+                    this.outputLoop(sink, inputMessageMetricAnnotator, sinkRetrier),
+                ]
+            );
 
             await Promise.all(processes);
         } catch (e) {

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -107,6 +107,10 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
         }
     }
 
+    public getInputQueueLength(): number {
+        return this.inputQueue.length;
+    }
+
     private async inputLoop(source: IInputSource): Promise<void> {
         const inputContext: IInputSourceContext = {
             evict: async (predicate: (MessageRef) => boolean): Promise<void> => {

--- a/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
+++ b/packages/core/src/internal/processor/ConcurrentMessageProcessor.ts
@@ -96,7 +96,6 @@ export class ConcurrentMessageProcessor extends BaseMessageProcessor implements 
                     }
                 }
             }, this.config.healthCheck.inputQueueValidation.validationIntervalInMs);
-            this.queueValidationTimer.unref();
         });
     }
 

--- a/packages/core/src/internal/processor/IMessageProcessor.ts
+++ b/packages/core/src/internal/processor/IMessageProcessor.ts
@@ -44,4 +44,6 @@ export interface IMessageProcessor extends IRequireInitialization {
         dispatchRetrier: IRetrier,
         sinkRetrier: IRetrier
     ): Promise<void>;
+
+    getInputQueueLength(): number;
 }

--- a/packages/core/src/internal/processor/SerialMessageProcessor.ts
+++ b/packages/core/src/internal/processor/SerialMessageProcessor.ts
@@ -37,6 +37,11 @@ export class SerialMessageProcessor extends BaseMessageProcessor implements IMes
         return SerialMessageProcessor.name;
     }
 
+    public getInputQueueLength(): number {
+        // It is no longer recommended to use serial mode so not adding this new functionality for it.
+        throw new Error("getInputQueueLength not supported for applications running in serial mode");
+    }
+
     public async run(
         source: IInputSource,
         inputMessageMetricAnnotator: IMessageMetricAnnotator,

--- a/packages/core/src/internal/processor/SerialMessageProcessor.ts
+++ b/packages/core/src/internal/processor/SerialMessageProcessor.ts
@@ -39,7 +39,9 @@ export class SerialMessageProcessor extends BaseMessageProcessor implements IMes
 
     public getInputQueueLength(): number {
         // It is no longer recommended to use serial mode so not adding this new functionality for it.
-        throw new Error("getInputQueueLength not supported for applications running in serial mode");
+        throw new Error(
+            "getInputQueueLength not supported for applications running in serial mode"
+        );
     }
 
     public async run(

--- a/packages/core/src/model/dsl.ts
+++ b/packages/core/src/model/dsl.ts
@@ -82,6 +82,11 @@ export enum ErrorHandlingMode {
     LogAndRetryOrFail,
 }
 
+export enum QueueFullHandlingMode {
+    LogAndContinue = 1,
+    LogAndFail,
+}
+
 export enum RetryMode {
     Linear = 1,
     Exponential,
@@ -99,6 +104,7 @@ export interface IParallelismConfiguration {
 }
 
 export interface IQueueValidationConfig {
+    readonly mode: QueueFullHandlingMode;
     readonly validationIntervalInMs: number;
     readonly timeOutInMs: number;
 }

--- a/packages/core/src/model/dsl.ts
+++ b/packages/core/src/model/dsl.ts
@@ -109,6 +109,9 @@ export interface IQueueValidationConfig {
     readonly timeOutInMs: number;
 }
 
+export interface IHealthCheckConfig {
+    readonly inputQueueValidation?: IQueueValidationConfig;
+}
 export interface IConcurrencyConfiguration {
     readonly emitMetricsForBatches?: boolean;
     readonly emitMetricsForQueues?: boolean;
@@ -120,7 +123,7 @@ export interface IConcurrencyConfiguration {
     readonly minimumBatchSize?: number;
     readonly maximumBatchSize?: number;
     readonly maximumParallelRpcRequests?: number;
-    readonly inputQueueValidationConfig?: IQueueValidationConfig;
+    readonly healthCheck?: IHealthCheckConfig;
 }
 
 export interface IApplicationRuntimeBehavior {

--- a/packages/core/src/model/dsl.ts
+++ b/packages/core/src/model/dsl.ts
@@ -112,6 +112,7 @@ export interface IQueueValidationConfig {
 export interface IHealthCheckConfig {
     readonly inputQueueValidation?: IQueueValidationConfig;
 }
+
 export interface IConcurrencyConfiguration {
     readonly emitMetricsForBatches?: boolean;
     readonly emitMetricsForQueues?: boolean;

--- a/packages/core/src/model/dsl.ts
+++ b/packages/core/src/model/dsl.ts
@@ -46,6 +46,7 @@ export interface IApplicationBuilder {
     services(): IServiceRegistryBuilder;
     output(): IOutputBuilder;
     if(predicate: boolean, action: (app: IApplicationBuilder) => void): IApplicationBuilder;
+    inputQueueLength(): number;
 }
 
 export interface IInputBuilder {

--- a/packages/core/src/model/dsl.ts
+++ b/packages/core/src/model/dsl.ts
@@ -98,6 +98,11 @@ export interface IParallelismConfiguration {
     readonly concurrencyConfiguration?: IConcurrencyConfiguration;
 }
 
+export interface IQueueValidationConfig {
+    readonly validationIntervalInMs: number;
+    readonly timeOutInMs: number;
+}
+
 export interface IConcurrencyConfiguration {
     readonly emitMetricsForBatches?: boolean;
     readonly emitMetricsForQueues?: boolean;
@@ -109,6 +114,7 @@ export interface IConcurrencyConfiguration {
     readonly minimumBatchSize?: number;
     readonly maximumBatchSize?: number;
     readonly maximumParallelRpcRequests?: number;
+    readonly inputQueueValidationConfig?: IQueueValidationConfig;
 }
 
 export interface IApplicationRuntimeBehavior {

--- a/packages/core/src/model/metrics.ts
+++ b/packages/core/src/model/metrics.ts
@@ -27,6 +27,7 @@ export enum MessageProcessingMetrics {
     InputQueue = "cookie_cutter.core.input_queue",
     OutputQueue = "cookie_cutter.core.output_queue",
     ConcurrentHandlers = "cookie_cutter.core.concurrent_handlers",
+    InputQueueValidation = "cookie_cutter.health_check.input_queue_validation",
 }
 
 export enum MessageProcessingResults {
@@ -39,6 +40,7 @@ export enum MessageProcessingResults {
     ErrFailedMsgRelease = "error.failed_msg_release",
     ErrReprocessing = "error.reprocessing",
     Unhandled = "unhandled",
+    Failure = "failure",
 }
 
 export interface IMessageMetricAnnotator {

--- a/packages/core/src/utils/BoundedPriorityQueue.ts
+++ b/packages/core/src/utils/BoundedPriorityQueue.ts
@@ -117,6 +117,10 @@ export class BoundedPriorityQueue<T> {
         }
     }
 
+    public isClosed(): boolean {
+        return this.closed;
+    }
+
     public async *iterate(): AsyncIterableIterator<T> {
         while (true) {
             try {


### PR DESCRIPTION
This health check will enable applications to auto heal/log if input queue of cc is full and no new messages from it are being processed for certain amount of time. It could be used as a guard for apps using kafka, redis, etc. and would be particularly helpful for kafka sources where we have a known issue because of cookie cutter uses sync callback to implement synchronization barrier for post rebalance async calls which sometimes causes consumers to be lost. Kafka JS has an open issue to add support for async callbacks but until that is done, this health check will help. Similarly it would be a good guard to add for apps with redis source as well.