### PR TITLE
BUG FIX: Only quit redis client if it's ready

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-redis",
-    "version": "1.6.0-beta.1",
+    "version": "1.6.0-beta.2",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/redis/src/RedisClient.ts
+++ b/packages/redis/src/RedisClient.ts
@@ -207,7 +207,9 @@ export class RedisClient implements IRedisClient, IRequireInitialization, IDispo
 
     public async dispose(): Promise<void> {
         this.disposeInitiated = true;
-        await this.client.quit();
+        if (this.client.isReady) {
+            await this.client.quit();
+        }
         this.client.unref();
     }
 

--- a/packages/redis/src/RedisClient.ts
+++ b/packages/redis/src/RedisClient.ts
@@ -207,7 +207,7 @@ export class RedisClient implements IRedisClient, IRequireInitialization, IDispo
 
     public async dispose(): Promise<void> {
         this.disposeInitiated = true;
-        // Avoid use of quit() to prevent hangs on unconnected clients beacuse it closes the client gracefully and wait for all the commands before closing. Issue: https://github.com/redis/node-redis/issues/2723
+        // Avoid use of quit() to prevent hangs on the unconnected clients beacuse it closes the client gracefully and wait for all the commands before closing. Issue: https://github.com/redis/node-redis/issues/2723
         // Immediately terminates the connection without waiting for any pending commands with disconnect().
         await this.client.disconnect();
         this.client.unref();

--- a/packages/redis/src/RedisClient.ts
+++ b/packages/redis/src/RedisClient.ts
@@ -207,9 +207,9 @@ export class RedisClient implements IRedisClient, IRequireInitialization, IDispo
 
     public async dispose(): Promise<void> {
         this.disposeInitiated = true;
-        if (this.client.isReady) {
-            await this.client.quit();
-        }
+        // Avoid use of quit() to prevent hangs on unconnected clients beacuse it closes the client gracefully and wait for all the commands before closing. Issue: https://github.com/redis/node-redis/issues/2723
+        // Immediately terminates the connection without waiting for any pending commands with disconnect().
+        await this.client.disconnect();
         this.client.unref();
     }
 


### PR DESCRIPTION
Invoking quit() on a Redis client that is not ready causes the application to hung, and the CC App is unable to dispose of the component, resulting in a hung CC application.