### PR TITLE
Enhance Redis client configuration to support cluster mode

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-redis",
-    "version": "1.6.0-beta.3",
+    "version": "1.6.0-beta.4",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/redis/src/RedisClient.ts
+++ b/packages/redis/src/RedisClient.ts
@@ -25,10 +25,12 @@ import {
     ClientClosedError,
     ConnectionTimeoutError,
     createClient,
+    createCluster,
     DisconnectsClientError,
     ErrorReply,
     ReconnectStrategyError,
     RedisClientType,
+    RedisClusterType,
     RootNodesUnavailableError,
     SocketClosedUnexpectedlyError,
     WatchError,
@@ -164,7 +166,7 @@ function getErrorName(error: any): string {
 }
 
 export class RedisClient implements IRedisClient, IRequireInitialization, IDisposable {
-    private readonly client: RedisClientType;
+    private readonly client: RedisClientType | RedisClusterType;
     private disposeInitiated: boolean = false;
     private readonly encoder: IMessageEncoder;
     private readonly typeMapper: IMessageTypeMapper;
@@ -176,17 +178,38 @@ export class RedisClient implements IRedisClient, IRequireInitialization, IDispo
     constructor(private readonly config: IRedisOptions) {
         this.encoder = config.encoder;
         this.typeMapper = config.typeMapper;
-        this.client = createClient({
-            socket: {
-                host: this.config.host,
-                port: this.config.port,
-                tls: this.config.tls,
-                ca: this.config.caPath ? readFileSync(this.config.caPath) : undefined,
-            },
-            username: this.config.username,
-            database: this.config.db,
-            password: this.config.password,
-        });
+        const socketConfig = {
+            tls: this.config.tls,
+            ca: this.config.caPath ? readFileSync(this.config.caPath) : undefined,
+            ...(this.config.checkServerIdentity === false && {
+                checkServerIdentity: () => undefined,
+            }),
+        };
+        if (config.clusterHostUrls && config.clusterHostUrls.length > 0) {
+            this.client = createCluster({
+                rootNodes: config.clusterHostUrls.map((url) => ({ url })),
+                defaults: {
+                    password: this.config.password,
+                    username: this.config.username,
+                    socket: socketConfig,
+                },
+            });
+        } else if (this.config.host && this.config.port) {
+            this.client = createClient({
+                socket: {
+                    ...socketConfig,
+                    host: this.config.host,
+                    port: this.config.port,
+                },
+                username: this.config.username,
+                database: this.config.db,
+                password: this.config.password,
+            });
+        } else {
+            throw new Error(
+                "Invalid Redis configuration: either hostUrls or host and port must be provided."
+            );
+        }
         this.client.on("connected", () => {
             this.logger.debug("Connection to Redis established");
         });
@@ -213,7 +236,6 @@ export class RedisClient implements IRedisClient, IRequireInitialization, IDispo
         // Avoid use of quit() to prevent hangs on the unconnected clients beacuse it closes the client gracefully and wait for all the commands before closing. Issue: https://github.com/redis/node-redis/issues/2723
         // Immediately terminates the connection without waiting for any pending commands with disconnect().
         await this.client.disconnect();
-        this.client.unref();
     }
 
     public async initialize(context: IComponentContext): Promise<void> {

--- a/packages/redis/src/__test__/client.integration.test.ts
+++ b/packages/redis/src/__test__/client.integration.test.ts
@@ -5,7 +5,7 @@ This source code is licensed under the Apache 2.0 license found in the
 LICENSE file in the root directory of this source tree.
 */
 
-import { createRedisClient } from "./utils";
+import { createRedisClient, createRedisClusterClient, createInvaildRedisClient } from "./utils";
 import { SpanContext } from "opentracing";
 import { DefaultComponentContext } from "@walmartlabs/cookie-cutter-core";
 
@@ -36,5 +36,38 @@ describe("RedisClient", () => {
         } finally {
             await client.dispose();
         }
+    });
+});
+
+describe("RedisClusterClient", () => {
+    it("returns undefined when retrieving a key that does not exist", async () => {
+        const client = createRedisClusterClient();
+        await client.initialize(DefaultComponentContext);
+        try {
+            const obj = await client.getObject(new SpanContext(), Uint8Array, "does-not-exist");
+            expect(obj).toBeUndefined();
+        } finally {
+            await client.dispose();
+        }
+    });
+
+    it("stores and retrieves and object by key", async () => {
+        const client = createRedisClusterClient();
+        await client.initialize(DefaultComponentContext);
+        try {
+            const expected = new TestClass("foo bar");
+            await client.putObject(new SpanContext(), TestClass, expected, "key-1");
+            const actual = await client.getObject(new SpanContext(), TestClass, "key-1");
+            expect(actual).toMatchObject(expected);
+        } finally {
+            await client.dispose();
+        }
+    });
+
+    it("throws an error if neither clusterHostUrls nor host is provided", async () => {
+        const client = createInvaildRedisClient();
+        expect(async () => await client.initialize(DefaultComponentContext)).toThrowError(
+            "Invalid Redis configuration: either hostUrls or host and port must be provided."
+        );
     });
 });

--- a/packages/redis/src/__test__/utils.ts
+++ b/packages/redis/src/__test__/utils.ts
@@ -26,6 +26,24 @@ export function createRedisClient(): Lifecycle<IRedisClient> {
     );
 }
 
+export function createRedisClusterClient(): Lifecycle<IRedisClient> {
+    return makeLifecycle(
+        redisClient({
+            clusterHostUrls: ["redis://localhost:6379"],
+            encoder: new JsonMessageEncoder(),
+            typeMapper: new ObjectNameMessageTypeMapper(),
+        })
+    );
+}
+
+export function createInvaildRedisClient(): Lifecycle<IRedisClient> {
+    return makeLifecycle(
+        redisClient({
+            encoder: new JsonMessageEncoder(),
+            typeMapper: new ObjectNameMessageTypeMapper(),
+        })
+    );
+}
 export class RepublishMessageDispatcher implements IMessageDispatcher {
     canDispatch(_: IMessage): boolean {
         return true;

--- a/packages/redis/src/config.ts
+++ b/packages/redis/src/config.ts
@@ -37,12 +37,29 @@ export class RedisOptions implements IRedisOptions {
         return config.noop();
     }
 
+    @config.field(config.converters.boolean)
+    public set checkServerIdentity(_: boolean) {
+        config.noop();
+    }
+
+    public get checkServerIdentity(): boolean {
+        return config.noop();
+    }
+
     @config.field(config.converters.string)
     public set host(_: string) {
         config.noop();
     }
     public get host(): string {
         return config.noop();
+    }
+
+    @config.field(config.converters.listOf(config.converters.string, ","))
+    public get clusterHostUrls(): string[] {
+        return config.noop();
+    }
+    public set clusterHostUrls(_: string[]) {
+        config.noop();
     }
 
     @config.field(config.converters.number)

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -31,12 +31,14 @@ export interface IRedisOptions {
     readonly tls?: boolean;
     readonly caPath?: string;
     readonly username?: string;
-    readonly host: string;
+    readonly host?: string;
+    readonly clusterHostUrls?: string[];
     readonly port?: number;
     readonly db?: number;
     readonly password?: string;
     readonly encoder: IMessageEncoder;
     readonly typeMapper?: IMessageTypeMapper;
+    readonly checkServerIdentity?: boolean;
     readonly base64Encode?: boolean;
 }
 


### PR DESCRIPTION
Description: 
- The constructor was updated to handle Redis cluster configurations.
- If clusterHostUrls are provided, a Redis cluster client is created using createCluster.
- If host and port are provided, a standalone Redis client is created using createClient.
- Error handling and event listeners were added for better connection management.