### PR TITLE
Fix Redis Stream Acknowledgment Error That Causes Application Deadlock

### DIFF
--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-redis",
-    "version": "1.6.0-beta.4",
+    "version": "1.6.0-beta.5",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/redis/src/RedisStreamSource.ts
+++ b/packages/redis/src/RedisStreamSource.ts
@@ -238,9 +238,8 @@ export class RedisStreamSource implements IInputSource, IRequireInitialization, 
             if (count !== 1) {
                 // Log the error but don't throw, to prevent blocking the message release process
                 // This approach prioritizes system stability (preventing deadlocks) over strict message processing guarantees. In a distributed system, this is often a reasonable tradeoff, as you can address message acknowledgment issues through monitoring and alerts rather than causing the entire application to hang.
-                this.logger.error(`Message ack returned ${count} (expected 1), message likely not in PEL`,
-                    { messageId, stream, consumerId });
-                this.logger.error("failed to ack message", { messageId, stream, consumerId });
+                this.logger.error("Message ack returned (expected 1), message likely not in PEL",
+                    { messageId, stream, consumerId, xAckCount: count });
                 this.metrics.increment(RedisMetrics.MsgAcknowledged, {
                     stream_name: stream,
                     consumer_group: consumerId,

--- a/packages/redis/src/RedisStreamSource.ts
+++ b/packages/redis/src/RedisStreamSource.ts
@@ -29,6 +29,7 @@ export enum RedisMetrics {
     MsgsClaimed = "cookie_cutter.redis_consumer.input_msgs_claimed",
     PendingMsgSize = "cookie_cutter.redis_consumer.pending_msg_size",
     IncomingBatchSize = "cookie_cutter.redis_consumer.incoming_batch_size",
+    MsgAcknowledged = "cookie_cutter.redis_consumer.input_msg_acknowledged",
 }
 
 export enum RedisMetricResult {
@@ -235,7 +236,16 @@ export class RedisStreamSource implements IInputSource, IRequireInitialization, 
 
             const count = await this.client.xAck(span.context(), stream, consumerId, messageId);
             if (count !== 1) {
-                throw new Error("not found in PEL");
+                // Log the error but don't throw, to prevent blocking the message release process
+                // This approach prioritizes system stability (preventing deadlocks) over strict message processing guarantees. In a distributed system, this is often a reasonable tradeoff, as you can address message acknowledgment issues through monitoring and alerts rather than causing the entire application to hang.
+                this.logger.error(`Message ack returned ${count} (expected 1), message likely not in PEL`,
+                    { messageId, stream, consumerId });
+                this.logger.error("failed to ack message", { messageId, stream, consumerId });
+                this.metrics.increment(RedisMetrics.MsgAcknowledged, {
+                    stream_name: stream,
+                    consumer_group: consumerId,
+                    result: RedisMetricResult.Error,
+                });
             }
 
             this.metrics.increment(RedisMetrics.MsgProcessed, {
@@ -250,11 +260,6 @@ export class RedisStreamSource implements IInputSource, IRequireInitialization, 
                 consumer_group: consumerId,
                 result: RedisMetricResult.Error,
             });
-
-            if (!err) {
-                this.logger.error("failed to ack message", e, { messageId, stream, consumerId });
-                throw e;
-            }
         } finally {
             span.finish();
         }

--- a/packages/redis/src/RedisStreamSource.ts
+++ b/packages/redis/src/RedisStreamSource.ts
@@ -238,8 +238,12 @@ export class RedisStreamSource implements IInputSource, IRequireInitialization, 
             if (count !== 1) {
                 // Log the error but don't throw, to prevent blocking the message release process
                 // This approach prioritizes system stability (preventing deadlocks) over strict message processing guarantees. In a distributed system, this is often a reasonable tradeoff, as you can address message acknowledgment issues through monitoring and alerts rather than causing the entire application to hang.
-                this.logger.error("Message ack returned (expected 1), message likely not in PEL",
-                    { messageId, stream, consumerId, xAckCount: count });
+                this.logger.error("Message ack returned (expected 1), message likely not in PEL", {
+                    messageId,
+                    stream,
+                    consumerId,
+                    xAckCount: count,
+                });
                 this.metrics.increment(RedisMetrics.MsgAcknowledged, {
                     stream_name: stream,
                     consumer_group: consumerId,


### PR DESCRIPTION
### Problem
Applications using Redis streams can get stuck in an infinite loop when Redis acknowledgments ([xAck](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) fail. This happens because the message processing pipeline does not properly handle errors during the message acknowledgment phase, preventing messages from being removed from the pending set in CompositeInputSource.

When an [xAck](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) operation returns 0 or throws an exception, the error handling in [RedisStreamSource.onMessageReleased](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) throws an exception, breaking the message release flow. This prevents messages from being properly removed from the pending messages set, causing the application to get stuck in the waiting loop in CompositeInputSource.

### Solution
This PR modifies the error handling in [RedisStreamSource.onMessageReleased](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to log errors instead of throwing exceptions when acknowledgment fails. This ensures the message release flow completes regardless of acknowledgment failures, preventing the application from deadlocking.

## Key changes:

Instead of throwing an error when [count !== 1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), we now log a warning message
In the catch block, we log errors but don't propagate them when !err is true
Added more detailed logging to help with troubleshooting
### Testing
Verified that the application continues processing messages even when Redis acknowledgments fail
Confirmed that errors are properly logged for troubleshooting
Checked that metrics are still updated to reflect acknowledgment failures
### Related Issues
Fixes #399 