### PR TITLE
Add timeout

### DIFF
--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@google-cloud/bigquery": "8.1.1",
-        "@google-cloud/pubsub": "5.2.0",
+        "@google-cloud/pubsub": "5.3.0",
         "@google-cloud/storage": "7.18.0"
     },
     "peerDependencies": {

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-gcp",
-    "version": "1.6.0-beta.4",
+    "version": "1.6.0-beta.5",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -140,6 +140,7 @@ export class PubSubSink
                             topic,
                             eventType,
                         });
+                        throw e;
                     }
                 } finally {
                     span.finish();

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -127,7 +127,13 @@ export class PubSubSink
                     this.logger.debug("Message published to PubSub", { topic, messageId });
                 } catch (e) {
                     failSpan(span, e);
-                    this.emitMetrics(topic, eventType, PubSubMetricResults.Error);
+                    topicPayload.messages.forEach((message) =>
+                        this.emitMetrics(
+                            topic,
+                            message.attributes[AttributeNames.eventType],
+                            PubSubMetricResults.Error
+                        )
+                    );
                     this.logger.error("Failed to publish message to PubSub", e, {
                         topic,
                         eventType,

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -20,7 +20,7 @@ import {
     failSpan,
 } from "@walmartlabs/cookie-cutter-core";
 import { Span, SpanContext, Tags, Tracer } from "opentracing";
-import { PubSub, Attributes, Topic } from "@google-cloud/pubsub";
+import { PubSub, Attributes } from "@google-cloud/pubsub";
 import { IGcpAuthConfiguration, IPubSubPublisherConfiguration } from ".";
 import {
     AttributeNames,
@@ -39,13 +39,6 @@ interface IPayloadWithAttributes {
 interface IPubSubTopicPayload {
     messages: IPayloadWithAttributes[];
     messageOrdering: boolean;
-}
-
-class PubSubPublishTimeoutError extends Error {
-    constructor(timeoutMs: number) {
-        super(`PubSub publish timed out after ${timeoutMs}ms`);
-        this.name = "PubSubPublishTimeoutError";
-    }
 }
 
 export enum PubSubMetadata {
@@ -109,6 +102,9 @@ export class PubSubSink
                     maxMessages: this.config.maximumBatchSize,
                     maxMilliseconds: this.config.maximumBatchWaitTime,
                 },
+                gaxOpts: {
+                    timeout: this.config.publishTimeoutMs,
+                },
                 messageOrdering: topicPayload.messageOrdering,
             });
             for (const message of topicPayload.messages) {
@@ -119,7 +115,11 @@ export class PubSubSink
                 const startTime = performance.now();
                 this.spanLogAndSetTags(span, this.sink.name, topic);
                 try {
-                    const messageId = await this.publishMessageWithTimeout(batchPublisher, message);
+                    const messageId = await batchPublisher.publishMessage({
+                        data: message.payload,
+                        attributes: message.attributes,
+                        orderingKey: message.orderingKey,
+                    });
                     span.log({ messageId });
                     this.emitMetrics(topic, eventType, PubSubMetricResults.Success);
                     const runTime = (performance.now() - startTime) / 1000;
@@ -127,21 +127,12 @@ export class PubSubSink
                     this.logger.debug("Message published to PubSub", { topic, messageId });
                 } catch (e) {
                     failSpan(span, e);
-                    if (e instanceof PubSubPublishTimeoutError) {
-                        this.emitMetrics(topic, eventType, PubSubMetricResults.Timeout);
-                        this.logger.warn("PubSub publish timed out, skipping", {
-                            topic,
-                            eventType,
-                            publishTimeoutMs: this.config.publishTimeoutMs,
-                        });
-                    } else {
-                        this.emitMetrics(topic, eventType, PubSubMetricResults.Error);
-                        this.logger.error("Failed to publish message to PubSub", e, {
-                            topic,
-                            eventType,
-                        });
-                        throw e;
-                    }
+                    this.emitMetrics(topic, eventType, PubSubMetricResults.Error);
+                    this.logger.error("Failed to publish message to PubSub", e, {
+                        topic,
+                        eventType,
+                    });
+                    throw e;
                 } finally {
                     span.finish();
                 }
@@ -184,36 +175,6 @@ export class PubSubSink
             topic,
             event_type: eventType,
         });
-    }
-
-    private async publishMessageWithTimeout(
-        batchPublisher: Topic,
-        message: IPayloadWithAttributes
-    ): Promise<string> {
-        const publishPromise = batchPublisher.publishMessage({
-            data: message.payload,
-            attributes: message.attributes,
-            orderingKey: message.orderingKey,
-        });
-
-        if (!this.config.publishTimeoutMs || this.config.publishTimeoutMs <= 0) {
-            return await publishPromise;
-        }
-
-        let timeout: NodeJS.Timeout | undefined;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            timeout = setTimeout(() => {
-                reject(new PubSubPublishTimeoutError(this.config.publishTimeoutMs));
-            }, this.config.publishTimeoutMs);
-        });
-
-        try {
-            return await Promise.race([publishPromise, timeoutPromise]);
-        } finally {
-            if (timeout) {
-                clearTimeout(timeout);
-            }
-        }
     }
 
     private formatMessage(msg: IPublishedMessage): IPayloadWithAttributes {

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -186,7 +186,7 @@ export class PubSubSink
     }
 
     private isPublishTimeoutError(error: any): boolean {
-        // 4 is the code for timeout
+        // 4 is the code for timeout/deadline-exceeded. https://grpc.io/docs/guides/status-codes/
         return error?.code === 4;
     }
 

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -20,7 +20,7 @@ import {
     failSpan,
 } from "@walmartlabs/cookie-cutter-core";
 import { Span, SpanContext, Tags, Tracer } from "opentracing";
-import { PubSub, Attributes } from "@google-cloud/pubsub";
+import { PubSub, Attributes, Topic } from "@google-cloud/pubsub";
 import { IGcpAuthConfiguration, IPubSubPublisherConfiguration } from ".";
 import {
     AttributeNames,
@@ -39,6 +39,13 @@ interface IPayloadWithAttributes {
 interface IPubSubTopicPayload {
     messages: IPayloadWithAttributes[];
     messageOrdering: boolean;
+}
+
+class PubSubPublishTimeoutError extends Error {
+    constructor(timeoutMs: number) {
+        super(`PubSub publish timed out after ${timeoutMs}ms`);
+        this.name = "PubSubPublishTimeoutError";
+    }
 }
 
 export enum PubSubMetadata {
@@ -108,31 +115,32 @@ export class PubSubSink
                 const span = this.tracer.startSpan(this.spanOperationName, {
                     childOf: message.spanContext,
                 });
+                const eventType = message.attributes[AttributeNames.eventType];
+                const startTime = performance.now();
                 this.spanLogAndSetTags(span, this.sink.name, topic);
                 try {
-                    const messageId = await batchPublisher.publishMessage({
-                        data: message.payload,
-                        attributes: message.attributes,
-                        orderingKey: message.orderingKey,
-                    });
-
+                    const messageId = await this.publishMessageWithTimeout(batchPublisher, message);
                     span.log({ messageId });
-                    this.emitMetrics(
-                        topic,
-                        message.attributes[AttributeNames.eventType],
-                        PubSubMetricResults.Success
-                    );
+                    this.emitMetrics(topic, eventType, PubSubMetricResults.Success);
+                    const runTime = (performance.now() - startTime) / 1000;
+                    this.emitPublishTimingMetric(topic, eventType, runTime);
                     this.logger.debug("Message published to PubSub", { topic, messageId });
                 } catch (e) {
                     failSpan(span, e);
-                    topicPayload.messages.forEach((message) =>
-                        this.emitMetrics(
+                    if (e instanceof PubSubPublishTimeoutError) {
+                        this.emitMetrics(topic, eventType, PubSubMetricResults.Timeout);
+                        this.logger.warn("PubSub publish timed out, skipping", {
                             topic,
-                            message.attributes[AttributeNames.eventType],
-                            PubSubMetricResults.Error
-                        )
-                    );
-                    throw e;
+                            eventType,
+                            publishTimeoutMs: this.config.publishTimeoutMs,
+                        });
+                    } else {
+                        this.emitMetrics(topic, eventType, PubSubMetricResults.Error);
+                        this.logger.error("Failed to publish message to PubSub, skipping", e, {
+                            topic,
+                            eventType,
+                        });
+                    }
                 } finally {
                     span.finish();
                 }
@@ -168,6 +176,43 @@ export class PubSubSink
             event_type: eventType,
             result,
         });
+    }
+
+    private emitPublishTimingMetric(topic: string, eventType: string, runTime: number) {
+        this.metrics.timing(PubSubMetrics.PublishTime, runTime, {
+            topic,
+            event_type: eventType,
+        });
+    }
+
+    private async publishMessageWithTimeout(
+        batchPublisher: Topic,
+        message: IPayloadWithAttributes
+    ): Promise<string> {
+        const publishPromise = batchPublisher.publishMessage({
+            data: message.payload,
+            attributes: message.attributes,
+            orderingKey: message.orderingKey,
+        });
+
+        if (!this.config.publishTimeoutMs || this.config.publishTimeoutMs <= 0) {
+            return await publishPromise;
+        }
+
+        let timeout: NodeJS.Timeout | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => {
+                reject(new PubSubPublishTimeoutError(this.config.publishTimeoutMs));
+            }, this.config.publishTimeoutMs);
+        });
+
+        try {
+            return await Promise.race([publishPromise, timeoutPromise]);
+        } finally {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+        }
     }
 
     private formatMessage(msg: IPublishedMessage): IPayloadWithAttributes {

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -136,7 +136,7 @@ export class PubSubSink
                         });
                     } else {
                         this.emitMetrics(topic, eventType, PubSubMetricResults.Error);
-                        this.logger.error("Failed to publish message to PubSub, skipping", e, {
+                        this.logger.error("Failed to publish message to PubSub", e, {
                             topic,
                             eventType,
                         });

--- a/packages/gcp/src/PubSubSink.ts
+++ b/packages/gcp/src/PubSubSink.ts
@@ -28,7 +28,6 @@ import {
     PubSubMetrics,
     PubSubOpenTracingTagKeys,
 } from "./model";
-
 interface IPayloadWithAttributes {
     payload: Buffer;
     attributes: Attributes;
@@ -127,18 +126,21 @@ export class PubSubSink
                     this.logger.debug("Message published to PubSub", { topic, messageId });
                 } catch (e) {
                     failSpan(span, e);
-                    topicPayload.messages.forEach((message) =>
-                        this.emitMetrics(
+                    if (this.isPublishTimeoutError(e)) {
+                        this.emitMetrics(topic, eventType, PubSubMetricResults.Timeout);
+                        this.logger.warn("PubSub publish timed out, skipping", {
                             topic,
-                            message.attributes[AttributeNames.eventType],
-                            PubSubMetricResults.Error
-                        )
-                    );
-                    this.logger.error("Failed to publish message to PubSub", e, {
-                        topic,
-                        eventType,
-                    });
-                    throw e;
+                            eventType,
+                            publishTimeoutMs: this.config.publishTimeoutMs,
+                        });
+                    } else {
+                        this.emitMetrics(topic, eventType, PubSubMetricResults.Error);
+                        this.logger.error("Failed to publish message to PubSub", e, {
+                            topic,
+                            eventType,
+                        });
+                        throw e;
+                    }
                 } finally {
                     span.finish();
                 }
@@ -181,6 +183,11 @@ export class PubSubSink
             topic,
             event_type: eventType,
         });
+    }
+
+    private isPublishTimeoutError(error: any): boolean {
+        // 4 is the code for timeout
+        return error?.code === 4;
     }
 
     private formatMessage(msg: IPublishedMessage): IPayloadWithAttributes {

--- a/packages/gcp/src/__test__/PubSubSink.test.ts
+++ b/packages/gcp/src/__test__/PubSubSink.test.ts
@@ -236,8 +236,7 @@ describe("PubSubSink Tests", () => {
         mockPublishFn.mockImplementation(() => {
             throw err;
         });
-        await expect(testApp).resolves.toBeUndefined();
-        expect(mockPublishFn).toBeCalledTimes(messagesWithoutTopic.length);
+        await expect(testApp).rejects.toThrowError();
     });
 
     it("times out publish attempts and continues processing", async () => {

--- a/packages/gcp/src/__test__/PubSubSink.test.ts
+++ b/packages/gcp/src/__test__/PubSubSink.test.ts
@@ -312,7 +312,7 @@ describe("PubSubSink Tests", () => {
         });
     });
 
-    it("emits error metrics and logs when publish times out", async () => {
+    it("emits timeout metrics and warning logs when publish times out", async () => {
         const metrics = {
             increment: jest.fn(),
             gauge: jest.fn(),
@@ -340,21 +340,18 @@ describe("PubSubSink Tests", () => {
         await (sink as any).initialize(ctx);
         await expect(
             sink.sink([createPublishedMessage(messagesWithoutTopic[0])][Symbol.iterator]())
-        ).rejects.toThrow(timeoutError);
+        ).resolves.toBeUndefined();
 
         expect(metrics.increment).toHaveBeenCalledWith(PubSubMetrics.MsgPublished, {
             topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
             event_type: TestEvent.name,
-            result: PubSubMetricResults.Error,
+            result: PubSubMetricResults.Timeout,
         });
-        expect(logger.error).toHaveBeenCalledWith(
-            "Failed to publish message to PubSub",
-            timeoutError,
-            {
-                topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
-                eventType: TestEvent.name,
-            }
-        );
-        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith("PubSub publish timed out, skipping", {
+            topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            eventType: TestEvent.name,
+            publishTimeoutMs: 5,
+        });
+        expect(logger.error).not.toHaveBeenCalled();
     });
 });

--- a/packages/gcp/src/__test__/PubSubSink.test.ts
+++ b/packages/gcp/src/__test__/PubSubSink.test.ts
@@ -87,7 +87,7 @@ describe("PubSubSink Tests", () => {
     const pubSubPublisherConfigurationWithDefaultTopic: IPubSubPublisherConfiguration = {
         defaultTopic: "defaultTopic",
         encoder: new JsonMessageEncoder(),
-        publishTimeoutMs: 0,
+        publishTimeoutMs: 5000,
     };
     const err = new Error("Test Error");
     const messagesWithoutTopic: IMessage[] = [
@@ -223,7 +223,7 @@ describe("PubSubSink Tests", () => {
         });
     });
 
-    it("rejects on error from PubSub topic", async () => {
+    it("rejects on error from PubSub topic creation", async () => {
         const testApp = createTestApp(messagesWithoutTopic, sink, ErrorHandlingMode.LogAndFail);
         mockTopic.mockImplementation(() => {
             throw err;
@@ -231,7 +231,7 @@ describe("PubSubSink Tests", () => {
         await expect(testApp).rejects.toThrowError();
     });
 
-    it("rejects on error from PubSub topic", async () => {
+    it("rejects on publish errors", async () => {
         const testApp = createTestApp(messagesWithoutTopic, sink, ErrorHandlingMode.LogAndFail);
         mockPublishFn.mockImplementation(() => {
             throw err;
@@ -239,21 +239,41 @@ describe("PubSubSink Tests", () => {
         await expect(testApp).rejects.toThrowError();
     });
 
-    it("times out publish attempts and continues processing", async () => {
+    it("passes the configured timeout through gax options", async () => {
         sink = pubSubSink({
             ...gcsAuthConfig,
             ...pubSubPublisherConfigurationWithDefaultTopic,
             publishTimeoutMs: 5,
         });
-        mockPublishFn.mockImplementation(() => new Promise(() => undefined));
 
         const testApp = createTestApp(
             [messagesWithoutTopic[0]],
             sink,
-            ErrorHandlingMode.LogAndFail
+            ErrorHandlingMode.LogAndContinue
         );
         await expect(testApp).resolves.toBeUndefined();
         expect(mockPublishFn).toBeCalledTimes(1);
+        expect(mockTopic).toHaveBeenCalledWith(
+            pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            expect.objectContaining({
+                gaxOpts: { timeout: 5 },
+            })
+        );
+    });
+
+    it("uses the default publish timeout of 5000ms", async () => {
+        const testApp = createTestApp(
+            [messagesWithoutTopic[0]],
+            sink,
+            ErrorHandlingMode.LogAndContinue
+        );
+        await expect(testApp).resolves.toBeUndefined();
+        expect(mockTopic).toHaveBeenCalledWith(
+            pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            expect.objectContaining({
+                gaxOpts: { timeout: 5000 },
+            })
+        );
     });
 
     it("emits publish timing metrics for successful publishes", async () => {
@@ -292,7 +312,7 @@ describe("PubSubSink Tests", () => {
         });
     });
 
-    it("emits timeout metrics and warning logs when publish times out", async () => {
+    it("emits error metrics and logs when publish times out", async () => {
         const metrics = {
             increment: jest.fn(),
             gauge: jest.fn(),
@@ -314,21 +334,27 @@ describe("PubSubSink Tests", () => {
             ...pubSubPublisherConfigurationWithDefaultTopic,
             publishTimeoutMs: 5,
         });
-        mockPublishFn.mockImplementation(() => new Promise(() => undefined));
+        const timeoutError = Object.assign(new Error("Deadline exceeded"), { code: 4 });
+        mockPublishFn.mockRejectedValue(timeoutError);
 
         await (sink as any).initialize(ctx);
-        await sink.sink([createPublishedMessage(messagesWithoutTopic[0])][Symbol.iterator]());
+        await expect(
+            sink.sink([createPublishedMessage(messagesWithoutTopic[0])][Symbol.iterator]())
+        ).rejects.toThrow(timeoutError);
 
         expect(metrics.increment).toHaveBeenCalledWith(PubSubMetrics.MsgPublished, {
             topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
             event_type: TestEvent.name,
-            result: PubSubMetricResults.Timeout,
+            result: PubSubMetricResults.Error,
         });
-        expect(logger.warn).toHaveBeenCalledWith("PubSub publish timed out, skipping", {
-            topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
-            eventType: TestEvent.name,
-            publishTimeoutMs: 5,
-        });
-        expect(logger.error).not.toHaveBeenCalled();
+        expect(logger.error).toHaveBeenCalledWith(
+            "Failed to publish message to PubSub",
+            timeoutError,
+            {
+                topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+                eventType: TestEvent.name,
+            }
+        );
+        expect(logger.warn).not.toHaveBeenCalled();
     });
 });

--- a/packages/gcp/src/__test__/PubSubSink.test.ts
+++ b/packages/gcp/src/__test__/PubSubSink.test.ts
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 import { PubSub } from "@google-cloud/pubsub";
 import {
+    IComponentContext,
     IMessage,
     MessageRef,
     JsonMessageEncoder,
@@ -20,9 +21,10 @@ import {
     StaticInputSource,
     IOutputSink,
 } from "@walmartlabs/cookie-cutter-core";
+import { MockTracer } from "opentracing";
 import { IPubSubPublisherConfiguration, IGcpAuthConfiguration, pubSubSink } from "..";
 import { PubSubMetadata } from "../PubSubSink";
-import { AttributeNames } from "../model";
+import { AttributeNames, PubSubMetrics, PubSubMetricResults } from "../model";
 
 jest.mock("@google-cloud/pubsub", () => {
     return {
@@ -64,6 +66,18 @@ function createTestApp(
         .run(retryMode);
 }
 
+function createPublishedMessage(message: IMessage): IPublishedMessage {
+    const tracer = new MockTracer();
+    const span = tracer.startSpan("test-message");
+
+    return {
+        message,
+        metadata: {},
+        original: {} as MessageRef,
+        spanContext: span.context(),
+    };
+}
+
 describe("PubSubSink Tests", () => {
     const gcsAuthConfig: IGcpAuthConfiguration = {
         projectId: "projectId",
@@ -73,6 +87,7 @@ describe("PubSubSink Tests", () => {
     const pubSubPublisherConfigurationWithDefaultTopic: IPubSubPublisherConfiguration = {
         defaultTopic: "defaultTopic",
         encoder: new JsonMessageEncoder(),
+        publishTimeoutMs: 0,
     };
     const err = new Error("Test Error");
     const messagesWithoutTopic: IMessage[] = [
@@ -221,6 +236,100 @@ describe("PubSubSink Tests", () => {
         mockPublishFn.mockImplementation(() => {
             throw err;
         });
-        await expect(testApp).rejects.toThrowError();
+        await expect(testApp).resolves.toBeUndefined();
+        expect(mockPublishFn).toBeCalledTimes(messagesWithoutTopic.length);
+    });
+
+    it("times out publish attempts and continues processing", async () => {
+        sink = pubSubSink({
+            ...gcsAuthConfig,
+            ...pubSubPublisherConfigurationWithDefaultTopic,
+            publishTimeoutMs: 5,
+        });
+        mockPublishFn.mockImplementation(() => new Promise(() => undefined));
+
+        const testApp = createTestApp(
+            [messagesWithoutTopic[0]],
+            sink,
+            ErrorHandlingMode.LogAndFail
+        );
+        await expect(testApp).resolves.toBeUndefined();
+        expect(mockPublishFn).toBeCalledTimes(1);
+    });
+
+    it("emits publish timing metrics for successful publishes", async () => {
+        const metrics = {
+            increment: jest.fn(),
+            gauge: jest.fn(),
+            timing: jest.fn(),
+        };
+        const logger = {
+            info: jest.fn(),
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+        const ctx = {
+            logger,
+            metrics,
+            tracer: new MockTracer(),
+        } as unknown as IComponentContext;
+        sink = pubSubSink({
+            ...gcsAuthConfig,
+            ...pubSubPublisherConfigurationWithDefaultTopic,
+        });
+
+        await (sink as any).initialize(ctx);
+        await sink.sink([createPublishedMessage(messagesWithoutTopic[0])][Symbol.iterator]());
+
+        expect(metrics.increment).toHaveBeenCalledWith(PubSubMetrics.MsgPublished, {
+            topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            event_type: TestEvent.name,
+            result: PubSubMetricResults.Success,
+        });
+        expect(metrics.timing).toHaveBeenCalledWith(PubSubMetrics.PublishTime, expect.any(Number), {
+            topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            event_type: TestEvent.name,
+        });
+    });
+
+    it("emits timeout metrics and warning logs when publish times out", async () => {
+        const metrics = {
+            increment: jest.fn(),
+            gauge: jest.fn(),
+            timing: jest.fn(),
+        };
+        const logger = {
+            info: jest.fn(),
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+        const ctx = {
+            logger,
+            metrics,
+            tracer: new MockTracer(),
+        } as unknown as IComponentContext;
+        sink = pubSubSink({
+            ...gcsAuthConfig,
+            ...pubSubPublisherConfigurationWithDefaultTopic,
+            publishTimeoutMs: 5,
+        });
+        mockPublishFn.mockImplementation(() => new Promise(() => undefined));
+
+        await (sink as any).initialize(ctx);
+        await sink.sink([createPublishedMessage(messagesWithoutTopic[0])][Symbol.iterator]());
+
+        expect(metrics.increment).toHaveBeenCalledWith(PubSubMetrics.MsgPublished, {
+            topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            event_type: TestEvent.name,
+            result: PubSubMetricResults.Timeout,
+        });
+        expect(logger.warn).toHaveBeenCalledWith("PubSub publish timed out, skipping", {
+            topic: pubSubPublisherConfigurationWithDefaultTopic.defaultTopic,
+            eventType: TestEvent.name,
+            publishTimeoutMs: 5,
+        });
+        expect(logger.error).not.toHaveBeenCalled();
     });
 });

--- a/packages/gcp/src/config.ts
+++ b/packages/gcp/src/config.ts
@@ -156,6 +156,14 @@ export class PubSubPublisherConfiguration
     public get maxPayloadSize(): number {
         return config.noop();
     }
+
+    @config.field(config.converters.timespan)
+    public set publishTimeoutMs(_: number) {
+        config.noop();
+    }
+    public get publishTimeoutMs(): number {
+        return config.noop();
+    }
 }
 
 @config.section

--- a/packages/gcp/src/index.ts
+++ b/packages/gcp/src/index.ts
@@ -135,7 +135,7 @@ export function pubSubSink(
         maximumBatchSize: 1000,
         maximumBatchWaitTime: 100,
         maxPayloadSize: 5242880,
-        publishTimeoutMs: 0,
+        publishTimeoutMs: 5000,
     });
     return new PubSubSink(configuration);
 }

--- a/packages/gcp/src/index.ts
+++ b/packages/gcp/src/index.ts
@@ -60,6 +60,7 @@ export interface IPubSubPublisherConfiguration {
     readonly maximumBatchSize?: number;
     readonly maximumBatchWaitTime?: number;
     readonly maxPayloadSize?: number;
+    readonly publishTimeoutMs?: number;
 }
 
 export interface IPubSubSubscriberConfiguration {
@@ -134,6 +135,7 @@ export function pubSubSink(
         maximumBatchSize: 1000,
         maximumBatchWaitTime: 100,
         maxPayloadSize: 5242880,
+        publishTimeoutMs: 0,
     });
     return new PubSubSink(configuration);
 }

--- a/packages/gcp/src/model.ts
+++ b/packages/gcp/src/model.ts
@@ -14,6 +14,7 @@ export const AttributeNames = {
 export enum PubSubMetricResults {
     Success = "success",
     Error = "error",
+    Timeout = "timeout",
 }
 
 export enum PubSubMetrics {

--- a/packages/gcp/src/model.ts
+++ b/packages/gcp/src/model.ts
@@ -14,10 +14,12 @@ export const AttributeNames = {
 export enum PubSubMetricResults {
     Success = "success",
     Error = "error",
+    Timeout = "timeout",
 }
 
 export enum PubSubMetrics {
     MsgPublished = "cookie_cutter.pubsub_sink.msg_published",
+    PublishTime = "cookie_cutter.pubsub_sink.publish_time",
     MsgSubscribed = "cookie_cutter.pubsub_source.msg_received",
 }
 

--- a/packages/gcp/src/model.ts
+++ b/packages/gcp/src/model.ts
@@ -14,7 +14,6 @@ export const AttributeNames = {
 export enum PubSubMetricResults {
     Success = "success",
     Error = "error",
-    Timeout = "timeout",
 }
 
 export enum PubSubMetrics {


### PR DESCRIPTION
In gcp package, when uploading data to google pubsub 'batchPublisher.publishMessage' makes a grpc call internally. Currently there is no timeout functionality to this call and if one call hangs, it blocks the whole sink processing. This issue is causing transaction-uploader-pubsub service to hang until the service is restarted. 

This change is to add timeout on  publishMessage call and add metrics to track upload times .