### PR TITLE
upgrade protobufjs to 7.6.5

### DIFF
--- a/examples/grpc-chat/package.json
+++ b/examples/grpc-chat/package.json
@@ -9,7 +9,7 @@
         "inquirer": "8.2.4"
     },
     "devDependencies": {
-        "protobufjs": "7.6.4",
+        "protobufjs": "7.6.5",
         "protobufjs-cli": "1.1.3"
     },
     "scripts": {

--- a/examples/grpc-echo-service/package.json
+++ b/examples/grpc-echo-service/package.json
@@ -8,7 +8,7 @@
         "@walmartlabs/cookie-cutter-grpc": "^1.6.0-beta"
     },
     "devDependencies": {
-        "protobufjs": "7.6.4",
+        "protobufjs": "7.6.5",
         "protobufjs-cli": "1.1.3"
     },
     "scripts": {

--- a/examples/integration-tests/package.json
+++ b/examples/integration-tests/package.json
@@ -8,7 +8,7 @@
         "@walmartlabs/cookie-cutter-grpc": "^1.6.0-beta"
     },
     "devDependencies": {
-        "protobufjs": "7.6.4",
+        "protobufjs": "7.6.5",
         "protobufjs-cli": "1.1.3"
     },
     "scripts": {

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@walmartlabs/cookie-cutter-proto",
-    "version": "1.6.0-beta.6",
+    "version": "1.6.0-beta.7",
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "long": "5.3.2",
-        "protobufjs": "7.6.4"
+        "protobufjs": "7.6.5"
     },
     "peerDependencies": {
         "@walmartlabs/cookie-cutter-core": "^1.6.0-beta"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11052,10 +11052,10 @@ protobufjs-cli@1.1.3:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.6.4, protobufjs@^7.4.0, protobufjs@^7.5.4, protobufjs@^7.5.5:
-  version "7.6.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.4.tgz#8bb000300026efd63eb7951d26e5dbb38f5658f2"
-  integrity sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==
+protobufjs@7.6.5, protobufjs@^7.4.0, protobufjs@^7.5.4, protobufjs@^7.5.5:
+  version "7.6.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
+  integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
### **PR Type**
fix for [CVE-2026-59877](https://nvd.nist.gov/vuln/detail/CVE-2026-59877)


___

### **Description**
- Update protobufjs dependency to patch version 7.6.5

